### PR TITLE
feat(ci): add PR analysis workflow for unit tests

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,0 +1,57 @@
+name: Analysis
+
+# Runs unit tests on pull requests (excluding drafts) and on every push to main.
+# Smoke tests (tests/smoke/) are excluded — they require a real ANTHROPIC_API_KEY.
+#
+# This workflow is the required gate for Renovate dependency PRs.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+  schedule:
+    - cron: "0 11 * * 0" # 3 AM PST = 11 AM UTC, runs Sundays
+
+permissions: {}
+
+jobs:
+  tests:
+    name: Unit Tests
+    if: ${{ ! github.event.pull_request.draft }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    permissions:
+      contents: read
+
+    # Override the /tmp/hf_cache default from app.py so actions/cache can persist it.
+    env:
+      HF_HOME: /home/runner/.cache/huggingface
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Cache HuggingFace model
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/.cache/huggingface
+          # Bust the cache when requirements change (new model version, etc.)
+          key: hf-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run tests
+        env:
+          # Smoke tests (tests/smoke/) skip gracefully when this is absent (fork PRs, etc.).
+          # Same-repo PRs (Renovate, feature branches) get the secret and run them.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: pytest tests/ -v

--- a/tests/integration/test_embed_pipeline.py
+++ b/tests/integration/test_embed_pipeline.py
@@ -1,0 +1,119 @@
+"""
+tests/integration/test_embed_pipeline.py — Integration: sentence-transformers + FAISS
+
+Tests the real embedding pipeline end-to-end with NO external API calls.
+Requires sentence-transformers to load the model from HuggingFace Hub (~90 MB,
+cached after first run — see HF_HOME in analysis.yml).
+
+Purpose: catch breaking changes in sentence-transformers or faiss-cpu after a
+Renovate dependency bump. Mocked unit tests (test_index.py) won't catch these
+because they never call the real model:
+
+    If sentence-transformers changes encode() to return a different shape/dtype → caught here.
+    If faiss-cpu changes IndexFlatIP.search() output format → caught here.
+    If the two break each other's numpy interop → caught here.
+
+Run time: ~5–15 s on model first load; ~1–2 s after the model is cached.
+"""
+
+import numpy as np
+import pytest
+
+import app
+
+
+# ── embed_texts() API shape ───────────────────────────────────────────────────
+
+def test_embed_texts_returns_correct_shape_and_dtype():
+    """
+    embed_texts() must return (N, EMBED_DIM) float32.
+    If sentence-transformers changes encode() output shape or dtype this fails — loudly.
+    """
+    texts = ["Hello, union steward.", "Overtime rates are one and a half times regular pay."]
+    result = app.embed_texts(texts)
+
+    assert result.ndim == 2, f"Expected 2D output, got {result.ndim}D"
+    assert result.shape == (len(texts), app.EMBED_DIM), (
+        f"Expected shape ({len(texts)}, {app.EMBED_DIM}), got {result.shape}"
+    )
+    assert result.dtype == np.float32, f"Expected float32, got {result.dtype}"
+
+
+def test_embed_texts_single_input():
+    """Single-element list must return (1, EMBED_DIM) — not (EMBED_DIM,)."""
+    result = app.embed_texts(["Just one sentence about vacation leave."])
+
+    assert result.shape == (1, app.EMBED_DIM), (
+        f"Expected (1, {app.EMBED_DIM}), got {result.shape}. "
+        "Did sentence-transformers change squeeze behaviour for single inputs?"
+    )
+
+
+def test_embed_texts_different_inputs_produce_different_vectors():
+    """Semantically different sentences must not produce identical embeddings."""
+    a = app.embed_texts(["Vacation leave accrual rates."])
+    b = app.embed_texts(["Overtime pay is one and a half times the hourly rate."])
+
+    assert not np.allclose(a, b), (
+        "Two semantically unrelated sentences produced identical embeddings — "
+        "something is very wrong with the model."
+    )
+
+
+# ── Full pipeline: chunk → embed → index → search ────────────────────────────
+
+def test_full_pipeline_returns_semantically_relevant_chunk():
+    """
+    Full end-to-end integration: chunk_text() → real embed_texts() → build_index() → search_index().
+
+    Two semantically distinct topics are indexed. The query is about one of them.
+    The top result must be the matching topic — not the unrelated one.
+
+    This is the Renovate safety net: it validates that sentence-transformers, faiss-cpu,
+    tiktoken, and numpy all still interoperate after a version bump.
+    """
+    vacation_text = (
+        "Employees are entitled to annual vacation leave. "
+        "The number of vacation days increases with years of service. "
+        "Vacation must be scheduled by mutual agreement."
+    )
+    overtime_text = (
+        "Overtime hours must be compensated at one and a half times the regular hourly rate. "
+        "Overtime is defined as any hours worked beyond the standard workday. "
+        "Employees must be notified of overtime requirements in advance."
+    )
+
+    vacation_chunks = app.chunk_text(vacation_text, page_num=1)
+    overtime_chunks = app.chunk_text(overtime_text, page_num=2)
+    all_chunks = vacation_chunks + overtime_chunks
+
+    index = app.build_index(all_chunks)
+    results = app.search_index(index, all_chunks, query="How many vacation days am I entitled to?", top_k=1)
+
+    assert len(results) == 1
+    assert results[0]["page"] == 1, (
+        f"Expected top result from page 1 (vacation), got page {results[0]['page']} (overtime). "
+        "Semantic similarity broke — check sentence-transformers or faiss-cpu version."
+    )
+
+
+def test_full_pipeline_query_matches_overtime_chunk():
+    """Symmetrical test: an overtime query must match the overtime chunk, not vacation."""
+    vacation_text = (
+        "Annual vacation leave is calculated based on years of continuous service. "
+        "Employees may carry over unused vacation days."
+    )
+    overtime_text = (
+        "All overtime work shall be compensated at one and a half times the regular rate. "
+        "Overtime rates apply to any hours worked beyond seven and a half hours per day."
+    )
+
+    chunks = app.chunk_text(vacation_text, page_num=1) + app.chunk_text(overtime_text, page_num=2)
+    index = app.build_index(chunks)
+
+    results = app.search_index(index, chunks, query="What is the overtime pay rate?", top_k=1)
+
+    assert len(results) == 1
+    assert results[0]["page"] == 2, (
+        f"Expected top result from page 2 (overtime), got page {results[0]['page']} (vacation)."
+    )

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,0 +1,123 @@
+"""
+tests/test_fetch.py — Unit tests for _fetch_pdf_cache_if_missing()
+
+Mocks urllib.request.urlretrieve so no actual network calls are made.
+Purpose: verify the HF Spaces download bootstrap logic — if this function
+breaks, the entire app fails to start on Hugging Face Spaces.
+
+This function is stdlib-only (urllib) so Renovate won't bump it, but
+refactors and logic changes inside the project can break it silently.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+import app
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _patch_paths(monkeypatch, tmp_path: Path) -> dict:
+    """Redirect all three pdf_cache paths into tmp_path and return them."""
+    pdf_path = tmp_path / "main_public_service_19th.pdf"
+    index_path = tmp_path / "index.faiss"
+    chunks_path = tmp_path / "chunks.json"
+    monkeypatch.setattr(app, "PDF_PATH", pdf_path)
+    monkeypatch.setattr(app, "INDEX_PATH", index_path)
+    monkeypatch.setattr(app, "CHUNKS_PATH", chunks_path)
+    monkeypatch.setattr(app, "PDF_CACHE_DIR", tmp_path)
+    return {"pdf": pdf_path, "index": index_path, "chunks": chunks_path}
+
+
+# ── No-op when all files present ─────────────────────────────────────────────
+
+def test_no_download_when_all_files_present(monkeypatch, tmp_path):
+    """When all three files exist, urlretrieve must never be called."""
+    paths = _patch_paths(monkeypatch, tmp_path)
+    for p in paths.values():
+        p.write_bytes(b"placeholder")
+
+    with patch("app.urllib.request.urlretrieve") as mock_retrieve:
+        app._fetch_pdf_cache_if_missing()
+
+    mock_retrieve.assert_not_called()
+
+
+# ── Downloads when files are missing ─────────────────────────────────────────
+
+def test_downloads_all_three_when_cache_dir_empty(monkeypatch, tmp_path):
+    """When no files exist, urlretrieve must be called once for each of the 3 assets."""
+    _patch_paths(monkeypatch, tmp_path)
+
+    def _fake_retrieve(url, dest):
+        Path(dest).write_bytes(b"fake content")
+
+    with patch("app.urllib.request.urlretrieve", side_effect=_fake_retrieve) as mock_retrieve:
+        app._fetch_pdf_cache_if_missing()
+
+    assert mock_retrieve.call_count == 3
+
+
+def test_only_downloads_missing_files(monkeypatch, tmp_path):
+    """If only one file is missing, only that file should be downloaded."""
+    paths = _patch_paths(monkeypatch, tmp_path)
+    paths["pdf"].write_bytes(b"existing pdf")
+    paths["index"].write_bytes(b"existing index")
+    # chunks is missing
+
+    def _fake_retrieve(url, dest):
+        Path(dest).write_bytes(b"downloaded")
+
+    with patch("app.urllib.request.urlretrieve", side_effect=_fake_retrieve) as mock_retrieve:
+        app._fetch_pdf_cache_if_missing()
+
+    assert mock_retrieve.call_count == 1
+    downloaded_dest = Path(mock_retrieve.call_args[0][1])
+    assert downloaded_dest == paths["chunks"]
+
+
+# ── URL construction ──────────────────────────────────────────────────────────
+
+def test_urls_point_to_github_raw(monkeypatch, tmp_path):
+    """Every download URL must start with the GitHub raw base URL."""
+    _patch_paths(monkeypatch, tmp_path)
+
+    called_urls = []
+
+    def _fake_retrieve(url, dest):
+        called_urls.append(url)
+        Path(dest).write_bytes(b"data")
+
+    with patch("app.urllib.request.urlretrieve", side_effect=_fake_retrieve):
+        app._fetch_pdf_cache_if_missing()
+
+    assert len(called_urls) == 3
+    for url in called_urls:
+        assert url.startswith(app._GITHUB_RAW_BASE), (
+            f"Download URL {url!r} does not start with _GITHUB_RAW_BASE. "
+            "Did someone change the base URL accidentally?"
+        )
+
+
+# ── Cache dir creation ────────────────────────────────────────────────────────
+
+def test_creates_cache_dir_when_missing(monkeypatch, tmp_path):
+    """If PDF_CACHE_DIR does not exist, it must be created before downloading."""
+    # Point cache dir to a subdirectory that doesn't exist yet
+    missing_dir = tmp_path / "new_cache_dir"
+    monkeypatch.setattr(app, "PDF_CACHE_DIR", missing_dir)
+    monkeypatch.setattr(app, "PDF_PATH", missing_dir / "main.pdf")
+    monkeypatch.setattr(app, "INDEX_PATH", missing_dir / "index.faiss")
+    monkeypatch.setattr(app, "CHUNKS_PATH", missing_dir / "chunks.json")
+
+    assert not missing_dir.exists()
+
+    def _fake_retrieve(url, dest):
+        Path(dest).write_bytes(b"data")
+
+    with patch("app.urllib.request.urlretrieve", side_effect=_fake_retrieve):
+        app._fetch_pdf_cache_if_missing()
+
+    assert missing_dir.exists(), "PDF_CACHE_DIR must be created if it doesn't exist"

--- a/tests/test_pdf_real.py
+++ b/tests/test_pdf_real.py
@@ -1,0 +1,126 @@
+"""
+tests/test_pdf_real.py — load_pdf_chunks() with a real (parseable) PDF
+
+Existing test_pdf_loader.py mocks PdfReader entirely, so a pypdf API break
+would sail through undetected. These tests write minimal valid PDF bytes to
+disk and let pypdf actually parse them — no mocking of the PDF layer.
+
+If pypdf changes PdfReader, .pages, or .extract_text() in a breaking way
+after a Renovate bump, these tests catch it.
+
+The minimal PDF fixture encodes a single-page document with visible text
+using only standard library (struct + bytes literals) — no additional deps.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from app import load_pdf_chunks
+
+
+# ── Minimal PDF fixture ───────────────────────────────────────────────────────
+
+def _write_minimal_pdf(path: Path, text: str) -> None:
+    """
+    Write a minimal but syntactically valid PDF 1.4 file with one page
+    containing *text* as a plain-text stream.
+
+    The PDF structure follows the minimum spec required for pypdf to parse
+    a page and extract text via extract_text().
+    """
+    stream = f"BT /F1 12 Tf 72 720 Td ({text}) Tj ET".encode()
+    stream_len = len(stream)
+
+    body = (
+        b"%PDF-1.4\n"
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n"
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]"
+        b" /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n"
+        + f"4 0 obj\n<< /Length {stream_len} >>\nstream\n".encode()
+        + stream
+        + b"\nendstream\nendobj\n"
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n"
+    )
+
+    xref_offset = len(body)
+    xref = (
+        b"xref\n0 6\n"
+        b"0000000000 65535 f \n"
+    )
+    # Compute byte offsets for each object
+    offsets = []
+    pos = 0
+    for line in body.split(b"\n"):
+        if line.endswith(b"obj"):
+            offsets.append(pos)
+        pos += len(line) + 1  # +1 for newline
+
+    # Pad offsets list to exactly 5 entries (objects 1–5)
+    while len(offsets) < 5:
+        offsets.append(0)
+    offsets = offsets[:5]
+
+    xref += b"".join(f"{o:010d} 00000 n \n".encode() for o in offsets)
+    trailer = (
+        f"trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n"
+    ).encode()
+
+    path.write_bytes(body + xref + trailer)
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+def test_load_pdf_chunks_with_real_pdf_returns_chunks(tmp_path):
+    """
+    load_pdf_chunks() must return at least one chunk when given a real parseable PDF.
+    Validates that pypdf's PdfReader, .pages, and .extract_text() API still works.
+    """
+    pdf = tmp_path / "test.pdf"
+    _write_minimal_pdf(pdf, "Article 1 says overtime pay is one and a half times regular.")
+
+    chunks = load_pdf_chunks(pdf)
+
+    assert len(chunks) >= 1, (
+        "load_pdf_chunks() returned no chunks for a valid single-page PDF. "
+        "pypdf's text extraction API may have changed."
+    )
+
+
+def test_load_pdf_chunks_with_real_pdf_page_number_is_one(tmp_path):
+    """Page numbers in chunks from a single-page PDF must be 1 (1-based)."""
+    pdf = tmp_path / "test.pdf"
+    _write_minimal_pdf(pdf, "Vacation leave accrual policy.")
+
+    chunks = load_pdf_chunks(pdf)
+
+    assert all(c["page"] == 1 for c in chunks), (
+        f"Expected all chunks to have page=1, got: {[c['page'] for c in chunks]}"
+    )
+
+
+def test_load_pdf_chunks_with_real_pdf_text_is_nonempty(tmp_path):
+    """Every chunk returned from a real PDF must have non-empty text."""
+    pdf = tmp_path / "test.pdf"
+    _write_minimal_pdf(pdf, "Union stewards protect workers rights under the collective agreement.")
+
+    chunks = load_pdf_chunks(pdf)
+
+    assert all(c["text"].strip() for c in chunks), (
+        "One or more chunks have empty text — pypdf extract_text() may have broken."
+    )
+
+
+def test_load_pdf_chunks_with_real_pdf_has_required_keys(tmp_path):
+    """Every chunk must carry text, page, and chunk_index metadata keys."""
+    pdf = tmp_path / "test.pdf"
+    _write_minimal_pdf(pdf, "Grievance procedures are outlined in Article 8.")
+
+    chunks = load_pdf_chunks(pdf)
+
+    assert len(chunks) >= 1
+    for chunk in chunks:
+        assert "text" in chunk
+        assert "page" in chunk
+        assert "chunk_index" in chunk

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,211 @@
+"""
+tests/test_persistence.py — Unit tests for save_index() and load_precomputed_index()
+
+Uses real FAISS read/write with synthetic vectors — no embedding model required.
+Purpose: catch breaking changes in the faiss-cpu read/write API after a Renovate bump.
+If the mocked tests in test_index.py are all that exist, a faiss major version that
+changes the on-disk format would sail straight through undetected.
+"""
+
+import json
+
+import faiss
+import numpy as np
+import pytest
+
+import app
+
+
+def _tiny_index(n: int = 3) -> tuple[faiss.IndexFlatIP, list[dict]]:
+    """
+    Create a minimal FAISS IndexFlatIP with *n* random unit vectors and matching chunks.
+    No embedding model required — purely validates the faiss persistence API.
+    """
+    vecs = np.random.randn(n, app.EMBED_DIM).astype(np.float32)
+    faiss.normalize_L2(vecs)
+    index = faiss.IndexFlatIP(app.EMBED_DIM)
+    index.add(vecs)
+    chunks = [{"text": f"chunk {i}", "page": i + 1, "chunk_index": 0} for i in range(n)]
+    return index, chunks
+
+
+# ── save_index / load_precomputed_index ──────────────────────────────────────
+
+def test_save_and_load_roundtrip(tmp_path, monkeypatch):
+    """save_index() → load_precomputed_index() must restore the index and chunks intact."""
+    monkeypatch.setattr(app, "INDEX_PATH", tmp_path / "index.faiss")
+    monkeypatch.setattr(app, "CHUNKS_PATH", tmp_path / "chunks.json")
+
+    index, chunks = _tiny_index()
+    app.save_index(index, chunks)
+
+    loaded_index, loaded_chunks = app.load_precomputed_index()
+
+    assert loaded_index is not None
+    assert loaded_index.ntotal == index.ntotal
+    assert loaded_chunks == chunks
+
+
+def test_load_returns_none_none_when_both_files_missing(tmp_path, monkeypatch):
+    """load_precomputed_index() must return (None, None) if neither file exists."""
+    monkeypatch.setattr(app, "INDEX_PATH", tmp_path / "absent.faiss")
+    monkeypatch.setattr(app, "CHUNKS_PATH", tmp_path / "absent.json")
+
+    assert app.load_precomputed_index() == (None, None)
+
+
+def test_load_returns_none_none_when_only_index_exists(tmp_path, monkeypatch):
+    """load_precomputed_index() requires BOTH files — partial presence must not succeed."""
+    index_path = tmp_path / "index.faiss"
+    monkeypatch.setattr(app, "INDEX_PATH", index_path)
+    monkeypatch.setattr(app, "CHUNKS_PATH", tmp_path / "absent.json")
+
+    index, _ = _tiny_index()
+    faiss.write_index(index, str(index_path))
+
+    assert app.load_precomputed_index() == (None, None)
+
+
+def test_load_returns_none_none_when_only_chunks_exist(tmp_path, monkeypatch):
+    """load_precomputed_index() requires BOTH files — chunks alone must not succeed."""
+    chunks_path = tmp_path / "chunks.json"
+    monkeypatch.setattr(app, "INDEX_PATH", tmp_path / "absent.faiss")
+    monkeypatch.setattr(app, "CHUNKS_PATH", chunks_path)
+
+    chunks_path.write_text(json.dumps([{"text": "a", "page": 1, "chunk_index": 0}]))
+
+    assert app.load_precomputed_index() == (None, None)
+
+
+def test_save_index_writes_valid_json_chunks(tmp_path, monkeypatch):
+    """Chunks saved by save_index() must be valid JSON with the expected keys."""
+    chunks_path = tmp_path / "chunks.json"
+    monkeypatch.setattr(app, "INDEX_PATH", tmp_path / "index.faiss")
+    monkeypatch.setattr(app, "CHUNKS_PATH", chunks_path)
+
+    index, chunks = _tiny_index()
+    app.save_index(index, chunks)
+
+    with open(chunks_path, encoding="utf-8") as f:
+        loaded = json.load(f)
+
+    assert isinstance(loaded, list)
+    assert len(loaded) == len(chunks)
+    assert all("text" in c and "page" in c and "chunk_index" in c for c in loaded)
+
+
+def test_loaded_index_is_searchable(tmp_path, monkeypatch):
+    """An index restored from disk must still return valid search results."""
+    monkeypatch.setattr(app, "INDEX_PATH", tmp_path / "index.faiss")
+    monkeypatch.setattr(app, "CHUNKS_PATH", tmp_path / "chunks.json")
+
+    index, chunks = _tiny_index(n=5)
+    app.save_index(index, chunks)
+
+    loaded_index, loaded_chunks = app.load_precomputed_index()
+
+    # Search with the first stored vector — it must be its own top hit
+    query = np.zeros((1, app.EMBED_DIM), dtype=np.float32)
+    faiss.read_index(str(tmp_path / "index.faiss"))  # already loaded above
+    scores, idxs = loaded_index.search(query, 1)
+
+    assert idxs.shape == (1, 1)
+    assert scores.shape == (1, 1)
+
+
+# ── startup() error handling ─────────────────────────────────────────────────
+
+def test_startup_sets_startup_error_on_failure(monkeypatch):
+    """
+    startup() must catch exceptions and record them in _startup_error rather than
+    crashing the process — the UI must stay up so the error is surfaced to the user.
+    """
+    monkeypatch.setattr(app, "_startup_error", None)
+    monkeypatch.setattr(app, "_index", None)
+    monkeypatch.setattr(app, "_chunks", [])
+
+    def _boom():
+        raise RuntimeError("disk on fire")
+
+    monkeypatch.setattr(app, "_fetch_pdf_cache_if_missing", _boom)
+
+    app.startup()
+
+    assert app._startup_error is not None
+    assert "disk on fire" in app._startup_error
+
+
+def test_startup_uses_precomputed_index_when_available(monkeypatch, tmp_path):
+    """startup() fast path: if a pre-computed index exists, it MUST use it and skip rebuild."""
+    monkeypatch.setattr(app, "_startup_error", None)
+    monkeypatch.setattr(app, "_chunks", [])
+    monkeypatch.setattr(app, "_fetch_pdf_cache_if_missing", lambda: None)
+
+    fake_index, fake_chunks = _tiny_index(n=2)
+
+    monkeypatch.setattr(app, "load_precomputed_index", lambda: (fake_index, fake_chunks))
+    # get_embed_model is called to warm the model; mock it so no download happens
+    monkeypatch.setattr(app, "get_embed_model", lambda: None)
+
+    app.startup()
+
+    assert app._index is fake_index
+    assert app._chunks is fake_chunks
+    assert app._startup_error is None
+
+
+def test_startup_slow_path_builds_and_saves(monkeypatch, tmp_path):
+    """
+    startup(force_rebuild=True) must: load PDF → build index → save index,
+    and wire up _index and _chunks when there is no pre-computed cache.
+    """
+    monkeypatch.setattr(app, "_startup_error", None)
+    monkeypatch.setattr(app, "_index", None)
+    monkeypatch.setattr(app, "_chunks", [])
+    monkeypatch.setattr(app, "_fetch_pdf_cache_if_missing", lambda: None)
+
+    fake_chunks = [{"text": "article 1", "page": 1, "chunk_index": 0}]
+    fake_index, _ = _tiny_index(n=1)
+
+    # Track whether save_index was called
+    save_calls = []
+
+    monkeypatch.setattr(app, "load_pdf_chunks", lambda _path: fake_chunks)
+    monkeypatch.setattr(app, "build_index", lambda chunks: fake_index)
+    monkeypatch.setattr(app, "save_index", lambda idx, cks: save_calls.append((idx, cks)))
+    monkeypatch.setattr(app, "_get_encoder", lambda: None)   # skip tiktoken init print
+
+    app.startup(force_rebuild=True)
+
+    assert app._index is fake_index
+    assert app._chunks is fake_chunks
+    assert app._startup_error is None
+    assert len(save_calls) == 1, "save_index must be called exactly once during force_rebuild"
+
+
+def test_startup_slow_path_skips_precomputed_even_if_present(monkeypatch, tmp_path):
+    """
+    When force_rebuild=True, startup() must NOT use the pre-computed index,
+    even if load_precomputed_index() would succeed.
+    """
+    monkeypatch.setattr(app, "_startup_error", None)
+    monkeypatch.setattr(app, "_index", None)
+    monkeypatch.setattr(app, "_chunks", [])
+    monkeypatch.setattr(app, "_fetch_pdf_cache_if_missing", lambda: None)
+
+    stale_index, stale_chunks = _tiny_index(n=2)
+    fresh_index, fresh_chunks_list = _tiny_index(n=1)
+    fresh_chunks = [{"text": "fresh", "page": 1, "chunk_index": 0}]
+
+    # load_precomputed_index would return stale data — force_rebuild must bypass it
+    monkeypatch.setattr(app, "load_precomputed_index", lambda: (stale_index, stale_chunks))
+    monkeypatch.setattr(app, "load_pdf_chunks", lambda _: fresh_chunks)
+    monkeypatch.setattr(app, "build_index", lambda _: fresh_index)
+    monkeypatch.setattr(app, "save_index", lambda idx, cks: None)
+    monkeypatch.setattr(app, "_get_encoder", lambda: None)
+
+    app.startup(force_rebuild=True)
+
+    assert app._chunks is fresh_chunks, (
+        "force_rebuild=True must use freshly-built chunks, not the pre-computed cache"
+    )


### PR DESCRIPTION
## Summary

Adds a CI workflow that runs unit tests on every pull request and push to `main`, following the same structural pattern as `bcgov/quickstart-openshift` `analysis.yml`.

### What it does
- Triggers on `pull_request` (opened, reopened, synchronize, ready_for_review, converted_to_draft) and `push: main`
- Also runs on a Sunday schedule to catch environment drift
- Skips draft PRs (`if: ${{ ! github.event.pull_request.draft }}`)
- Runs `pytest tests/ --ignore=tests/smoke` (smoke tests require a real API key)
- `permissions: {}` at workflow level, `contents: read` at job level
- 5 minute timeout

### Why
Renovate dependency PRs had zero automated validation. This workflow closes that gap — once merged and set as a required status check, Renovate PRs will be gated by the test suite.