### PR TITLE
fix(ci): migrate analysis workflow from pip to uv

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -33,25 +33,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.12"
-          cache: pip
 
       - name: Cache HuggingFace model
         uses: actions/cache@v4
         with:
           path: /home/runner/.cache/huggingface
-          # Bust the cache when requirements change (new model version, etc.)
-          key: hf-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+          # Bust the cache when dependencies change (new model version, etc.)
+          key: hf-${{ runner.os }}-${{ hashFiles('uv.lock') }}
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: uv sync
 
       - name: Run tests
         env:
           # Smoke tests (tests/smoke/) skip gracefully when this is absent (fork PRs, etc.).
           # Same-repo PRs (Renovate, feature branches) get the secret and run them.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: pytest tests/ -v
+        run: uv run pytest tests/ -v


### PR DESCRIPTION
## Summary

The `requirements.txt` file was dropped in favour of `uv`, but the CI workflow was never updated. This caused the `Analysis` workflow to fail with:

````
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'\n````\n\n## Changes\n\n- Replace `actions/setup-python` with `astral-sh/setup-uv@v5`\n- Replace `pip install -r requirements.txt` with `uv sync`\n- Replace `pytest` with `uv run pytest`\n- Update HF model cache key to hash `uv.lock` instead of the now-deleted `requirements.txt`