### PR TITLE
fix(ci): correct actions/checkout version v6 -> v4 in deploy workflow

### DIFF
--- a/.github/workflows/deploy-hf-spaces.yml
+++ b/.github/workflows/deploy-hf-spaces.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0        # full history so git push works correctly
           lfs: false            # no LFS — pdf_cache/ files are regular git objects


### PR DESCRIPTION
## Summary

Found while verifying the deploy workflow ahead of a release. `actions/checkout@v6` does not exist — latest is `v4`. This would have caused the `Deploy to Hugging Face Spaces` workflow to immediately fail on checkout before doing anything useful.

One-line typo fix.