### PR TITLE
fix(ci): add pip dry-run step to prove requirements.txt resolves

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -45,6 +45,11 @@ jobs:
           # Bust the cache when dependencies change (new model version, etc.)
           key: hf-${{ runner.os }}-${{ hashFiles('uv.lock') }}
 
+      - name: Validate requirements.txt resolves against public indexes
+        # Proves every pinned version in requirements.txt actually exists on PyPI
+        # and the PyTorch CPU wheel index. --dry-run resolves without downloading.
+        run: pip install --dry-run -r requirements.txt
+
       - name: Install dependencies
         run: uv sync
 


### PR DESCRIPTION
## Summary

Adds a CI verification step that proves every version in `requirements.txt` actually exists on PyPI and the PyTorch CPU wheel index — before the uv install step.

````yaml
- name: Validate requirements.txt resolves against public indexes
  run: pip install --dry-run -r requirements.txt
````

`--dry-run` resolves the full dependency graph without downloading anything. If any pinned version does not exist on a reachable index, CI fails and the PR cannot merge.

This makes verification of `requirements.txt` a hard gate rather than an assertion.