### PR TITLE
fix(deploy): remove gradio pin — HF Spaces forces sdk_version

### DIFF
--- a/app.py
+++ b/app.py
@@ -424,9 +424,8 @@ def build_ui() -> gr.Blocks:
 
         # ── Chat interface ────────────────────────────────────────────────────
         chatbot = gr.Chatbot(
-            type="messages",
             height=480,
-            show_copy_button=True,
+            buttons=["copy"],
             render_markdown=True,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "BCGEU Collective Agreement RAG Chatbot"
 requires-python = ">=3.12"
 dependencies = [
     # ── Web UI ──────────────────────────────────────────────────────────────
-    "gradio>=6.7.0,<6.7.1",
+    "gradio>=6.7.0",
 
     # ── LLM ─────────────────────────────────────────────────────────────────
     "anthropic>=0.84.0",            # Claude API client

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@
 # https://github.com/DerekRoberts/vexilon
 
 # ── Web UI ───────────────────────────────────────────────────────────────────
-gradio>=6.7.0,<6.7.1
+# gradio version is controlled by HF Spaces via sdk_version in README.md.
+# Do NOT pin gradio here — HF forces its own version and pip will conflict.
 
 # ── LLM ──────────────────────────────────────────────────────────────────────
 anthropic>=0.84.0           # Claude API client

--- a/uv.lock
+++ b/uv.lock
@@ -1817,7 +1817,7 @@ dev = [
 requires-dist = [
     { name = "anthropic", specifier = ">=0.84.0" },
     { name = "faiss-cpu", specifier = ">=1.8.0" },
-    { name = "gradio", specifier = ">=6.7.0,<6.7.1" },
+    { name = "gradio", specifier = ">=6.7.0" },
     { name = "pypdf", specifier = ">=6.0.0" },
     { name = "sentence-transformers", specifier = ">=5.0.0" },
     { name = "tiktoken", specifier = ">=0.7.0" },


### PR DESCRIPTION
HF Spaces runs:
````
pip install -r requirements.txt gradio[oauth,mcp]==6.9.0
````

`gradio>=6.7.0,<6.7.1` in requirements.txt conflicts with the forced `==6.9.0`.

Fix: remove gradio from requirements.txt, uncap in pyproject.toml, use Gradio 6.9 API in app.py.