### PR TITLE
fix(deploy): bust HF build cache for CPU torch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 
 # BCGEU Collective Agreement RAG Chatbot
 # https://github.com/DerekRoberts/vexilon
+# cache-bust: 2026-03-09
 
 # ── Web UI ───────────────────────────────────────────────────────────────────
 # gradio version is controlled by HF Spaces via sdk_version in README.md.


### PR DESCRIPTION
Adds cache-bust comment to requirements.txt to force HF Spaces to re-run pip install. The current cached layer has the full CUDA torch which OOM-kills on cpu-basic (2GB). The fresh install will use --extra-index-url to get CPU-only torch (~200MB instead of 3GB).