### PR TITLE
feat: add TEST environment deployment to Hugging Face Spaces

### DIFF
--- a/.github/workflows/deploy-hf-spaces.yml
+++ b/.github/workflows/deploy-hf-spaces.yml
@@ -1,23 +1,30 @@
 name: Deploy to Hugging Face Spaces
 
-# Deploys to https://huggingface.co/spaces/DerekRoberts/vexilon
-# on every published GitHub release.
+# Deployments:
+# - TEST (landru): https://huggingface.co/spaces/DerekRoberts/landru
+#   → Push to main branch
+# - PROD (vexilon): https://huggingface.co/spaces/DerekRoberts/vexilon
+#   → Published GitHub release
 #
 # Required secret: HF_TOKEN
 #   GitHub → Settings → Secrets and variables → Actions → New repository secret
-#   Value: a Hugging Face token with WRITE access to the Space
+#   Value: a Hugging Face token with WRITE access to the Spaces
 #   https://huggingface.co/settings/tokens
 
 on:
+  push:
+    branches:
+      - main
   release:
     types: [published]
 
 permissions: {}
 
 jobs:
-  deploy:
-    name: Push to Hugging Face Space
+  deploy-test:
+    name: Push to TEST (landru)
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
 
     permissions:
       contents: read
@@ -26,15 +33,37 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0        # full history so git push works correctly
-          lfs: false            # no LFS — pdf_cache/ files are regular git objects
+          fetch-depth: 0
+          lfs: false
 
       - name: Push code-only snapshot to Hugging Face Space
-        # HF Spaces rejects binary files (.faiss, .pdf) via git push — even in history.
-        # app.py downloads pdf_cache/ from GitHub raw URLs at first startup instead.
-        # We create a fresh orphan commit (no history) with only code files, then
-        # force-push it to the HF Space's main branch.
-        # This approach never touches the GitHub repo history.
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          git config user.email "github-actions@github.com"
+          git config user.name "GitHub Actions"
+          git remote add hf "https://DerekRoberts:${HF_TOKEN}@huggingface.co/spaces/DerekRoberts/landru"
+          git checkout --orphan hf-snapshot
+          git rm --cached -r pdf_cache/
+          git commit -m "deploy: $(git log -1 --format='%s' HEAD@{1})"
+          git push hf hf-snapshot:main --force
+
+  deploy-prod:
+    name: Push to PROD (vexilon)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          lfs: false
+
+      - name: Push code-only snapshot to Hugging Face Space
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ article and page citations.
 
 ## Hosted
 
-🚀 **Live:** https://huggingface.co/spaces/DerekRoberts/vexilon
+🚀 **TEST:** https://huggingface.co/spaces/DerekRoberts/landru
+
+🚀 **PROD:** https://huggingface.co/spaces/DerekRoberts/vexilon
 
 ## Quick Start
 
@@ -108,7 +110,14 @@ All settings are optional — defaults match the product specification.
 
 ## Hugging Face Spaces Deployment
 
-The Space uses the Gradio SDK (`sdk: gradio`). HF installs [`requirements.txt`](requirements.txt)
+Two environments are available:
+
+| Environment | Space | URL | Trigger |
+|-------------|-------|-----|---------|
+| TEST | `landru` | https://huggingface.co/spaces/DerekRoberts/landru | Push to `main` |
+| PROD | `vexilon` | https://huggingface.co/spaces/DerekRoberts/vexilon | Published Release |
+
+The Spaces use the Gradio SDK (`sdk: gradio`). HF installs [`requirements.txt`](requirements.txt)
 and runs [`app.py`](app.py) directly. [`Containerfile`](Containerfile) is used for local
 development only and is ignored by HF Spaces.
 
@@ -125,8 +134,11 @@ This is a no-op when running locally (files are already present).
 
 ### Automated deploy (GitHub Actions)
 
-Every published GitHub release triggers [`.github/workflows/deploy-hf-spaces.yml`](.github/workflows/deploy-hf-spaces.yml),
-which strips `pdf_cache/` from the commit and pushes code-only to the HF Space.
+- **TEST** (`landru`): Every push to `main` triggers the workflow
+- **PROD** (`vexilon`): Every published GitHub release triggers the workflow
+
+The workflow [`.github/workflows/deploy-hf-spaces.yml`](.github/workflows/deploy-hf-spaces.yml)
+strips `pdf_cache/` from the commit and pushes code-only to the appropriate HF Space.
 
 **Required GitHub secret:**
 
@@ -134,7 +146,7 @@ which strips `pdf_cache/` from the commit and pushes code-only to the HF Space.
 |---|---|
 | `HF_TOKEN` | Hugging Face write-scoped access token ([settings/tokens](https://huggingface.co/settings/tokens)) |
 
-**Required HF Space secret** (set in [Space settings](https://huggingface.co/spaces/DerekRoberts/vexilon/settings)):
+**Required HF Space secrets** (set in each Space's settings):
 
 | Secret | Value |
 |---|---|


### PR DESCRIPTION
## Summary

This PR adds a TEST environment deployment to Hugging Face Spaces.

- Pushes to `main` will deploy to the TEST environment (`landru`).
- Published releases will deploy to the PROD environment (`vexilon`).
- Updated `README.md` to include links to both environments.