### PR TITLE
fix: grant contents read permission to deploy jobs

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -8,6 +8,8 @@ permissions: {}
 
 jobs:
   deploy-prod:
+    permissions:
+      contents: read
     uses: ./.github/workflows/deploy-hf-spaces-reusable.yml
     with:
       space_name: 'DerekRoberts/vexilon'

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -9,6 +9,8 @@ permissions: {}
 
 jobs:
   deploy-test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/deploy-hf-spaces-reusable.yml
     with:
       space_name: 'DerekRoberts/landru'


### PR DESCRIPTION
## Summary

Fixes an issue where the reusable workflow was failing because the caller workflows (`deploy-test.yml` and `deploy-prod.yml`) had `permissions: {}` at the top level, which restricted all permissions to `none`. This PR explicitly grants `contents: read` to the jobs calling the reusable workflow, allowing the `actions/checkout` step to succeed.