### PR TITLE
fix: resolve git error in HF deploy script

### DIFF
--- a/.github/workflows/deploy-hf-spaces-reusable.yml
+++ b/.github/workflows/deploy-hf-spaces-reusable.yml
@@ -31,7 +31,8 @@ jobs:
           git config user.email "github-actions@github.com"
           git config user.name "GitHub Actions"
           git remote add hf "https://DerekRoberts:${HF_TOKEN}@huggingface.co/spaces/${{ inputs.space_name }}"
+          COMMIT_MSG=$(git log -1 --format='%s')
           git checkout --orphan hf-snapshot
           git rm --cached -r pdf_cache/
-          git commit -m "deploy: $(git log -1 --format='%s' HEAD@{1})"
+          git commit -m "deploy: $COMMIT_MSG"
           git push hf hf-snapshot:main --force


### PR DESCRIPTION
## Summary

Fixes an issue where `git log -1 --format='%s' HEAD@{1}` fails because `HEAD@{1}` is invalid after checking out an orphan branch. This PR saves the commit message to a variable before creating the orphan branch.