### PR TITLE
feat: fix architecture drift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,4 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 screenshots/
 *.png
+test_output*.txt

--- a/SPEC.md
+++ b/SPEC.md
@@ -294,12 +294,12 @@ App startup
   └── Load PDF from pdf_cache/
   └── Parse pages with pypdf (preserve page numbers)
   └── Chunk text (512 tokens, 100 token overlap)
-  └── Embed all chunks with text-embedding-3-small
+  └── Embed all chunks with all-MiniLM-L6-v2
   └── Build FAISS index in memory
   └── Ready
 
 User sends message
-  └── Embed user query with text-embedding-3-small
+  └── Embed user query with all-MiniLM-L6-v2
   └── FAISS similarity search → top-5 chunks (with page numbers)
   └── Build prompt:
         system: [citation-enforcement rules + agreement context]
@@ -368,7 +368,7 @@ Open `http://localhost:7860`.
 ### Hugging Face Spaces
 
 - App type: Gradio
-- Secrets: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`
+- Secrets: `ANTHROPIC_API_KEY`
 - The `pdf_cache/` directory is committed to the repo and available at runtime
 - No persistent volume required (FAISS index rebuilt on each cold start — acceptable for this scale)
 

--- a/app.py
+++ b/app.py
@@ -3,7 +3,6 @@ app.py — Vexilon: BCGEU Agreement Assistant
 --------------------------------------------
 Tech stack:
   - pypdf                : PDF → pages with page number preservation
-  - tiktoken             : Token counting for chunking
   - sentence-transformers: Local CPU embeddings (all-MiniLM-L6-v2, no API key)
   - FAISS                : In-memory vector index (no server process)
   - Anthropic            : Claude (claude-haiku-4-5) for responses
@@ -36,10 +35,6 @@ os.environ.setdefault("HF_HOME", "/tmp/hf_cache")
 # ─── Third-party: PDF ────────────────────────────────────────────────────────
 print("[boot] Importing pypdf...", flush=True)
 from pypdf import PdfReader
-
-# ─── Third-party: Tokenizer ──────────────────────────────────────────────────
-print("[boot] Importing tiktoken...", flush=True)
-import tiktoken
 
 # ─── Third-party: Embeddings (local, no API key) ────────────────────────────
 print("[boot] Importing sentence_transformers (pulls torch)...", flush=True)
@@ -130,33 +125,32 @@ Response format:
 """
 
 # ─── Chunking ─────────────────────────────────────────────────────────────────
-# cl100k_base is used by text-embedding-3-small.
-# Lazy init: tiktoken downloads the BPE vocab (~1 MB) on first call if not cached;
-# we init inside startup() where we already have print() context.
-_ENCODER: tiktoken.Encoding | None = None
-
-
-def _get_encoder() -> tiktoken.Encoding:
-    global _ENCODER
-    if _ENCODER is None:
-        _ENCODER = tiktoken.get_encoding("cl100k_base")
-    return _ENCODER
-
 
 def chunk_text(text: str, page_num: int) -> list[dict]:
     """
-    Split *text* into overlapping token-based chunks.
+    Split *text* into overlapping token-based chunks using the embedding model's tokenizer.
     Returns list of dicts: {text, page, chunk_index}.
     """
-    enc = _get_encoder()
-    tokens = enc.encode(text)
+    tokenizer = get_embed_model().tokenizer
+    encoding = tokenizer(text, add_special_tokens=False, return_offsets_mapping=True)
+    tokens = encoding.input_ids
+    offsets = encoding.offset_mapping
     chunks = []
+    
+    if not tokens:
+        return chunks
+        
     start = 0
     idx = 0
     while start < len(tokens):
         end = min(start + CHUNK_SIZE, len(tokens))
-        chunk_tokens = tokens[start:end]
-        chunk_text_str = enc.decode(chunk_tokens)
+        
+        # We need the original text that spans these tokens to preserve original case
+        chunk_char_start = offsets[start][0]
+        chunk_char_end = offsets[end - 1][1]
+        
+        chunk_text_str = text[chunk_char_start:chunk_char_end]
+        
         chunks.append({
             "text": chunk_text_str,
             "page": page_num,
@@ -291,6 +285,7 @@ def startup(force_rebuild: bool = False) -> None:
     """
     global _chunks, _index, _startup_error
     try:
+        get_anthropic()  # Ping early to catch missing ANTHROPIC_API_KEY
         _fetch_pdf_cache_if_missing()
         if not force_rebuild:
             index, chunks = load_precomputed_index()
@@ -303,9 +298,6 @@ def startup(force_rebuild: bool = False) -> None:
                 return
 
         # ── Slow path: build from scratch ────────────────────────────────────
-        print("[startup] Initialising tokeniser (downloads BPE vocab on first run)…")
-        _get_encoder()
-        print("[startup] Tokeniser ready.")
         print(f"[startup] Loading PDF from {PDF_PATH}…")
         _chunks = load_pdf_chunks(PDF_PATH)
         print(f"[startup] {len(_chunks)} chunks loaded from {PDF_PATH.name}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ torch
 sentence-transformers
 faiss-cpu
 pypdf
-tiktoken

--- a/tests/integration/test_embed_pipeline.py
+++ b/tests/integration/test_embed_pipeline.py
@@ -70,7 +70,7 @@ def test_full_pipeline_returns_semantically_relevant_chunk():
     The top result must be the matching topic — not the unrelated one.
 
     This is the Renovate safety net: it validates that sentence-transformers, faiss-cpu,
-    tiktoken, and numpy all still interoperate after a version bump.
+    and numpy all still interoperate after a version bump.
     """
     vacation_text = (
         "Employees are entitled to annual vacation leave. "

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,16 +1,41 @@
-"""
-tests/test_chunking.py — Unit tests for chunk_text()
-
-Pure logic, no API calls, no mocking required.
-"""
-
-import tiktoken
 import pytest
+from unittest.mock import MagicMock
+import app
 from app import chunk_text, CHUNK_SIZE, CHUNK_OVERLAP
 
+@pytest.fixture(autouse=True)
+def mock_tokenizer(monkeypatch):
+    """
+    Mock the tokenizer used by get_embed_model() for all tests in this file.
+    This prevents the tests from downloading the real embedding model or
+    requiring an internet connection.
+    """
+    mock_tok = MagicMock()
+    
+    def _mock_tokenize(text, **kwargs):
+        words = text.split()
+        input_ids = list(range(len(words)))
+        offset_mapping = []
+        current_idx = 0
+        for word in words:
+            start = text.find(word, current_idx)
+            if start == -1:
+                # Fallback if find fails (e.g. punctuation differences)
+                start = current_idx
+            end = start + len(word)
+            offset_mapping.append((start, end))
+            current_idx = end
+            
+        return MagicMock(input_ids=input_ids, offset_mapping=offset_mapping)
+        
+    mock_tok.side_effect = _mock_tokenize
+    
+    mock_embed_model = MagicMock()
+    mock_embed_model.tokenizer = mock_tok
+    monkeypatch.setattr(app, "get_embed_model", lambda: mock_embed_model)
+    return mock_tok
 
 def test_short_text_produces_one_chunk():
-    """Text shorter than CHUNK_SIZE should produce exactly one chunk."""
     text = "Hello, this is a short sentence."
     chunks = chunk_text(text, page_num=1)
     assert len(chunks) == 1
@@ -18,55 +43,36 @@ def test_short_text_produces_one_chunk():
     assert chunks[0]["chunk_index"] == 0
     assert chunks[0]["text"] == text
 
-
 def test_chunk_metadata_fields():
-    """Every chunk must carry text, page, and chunk_index keys."""
     chunks = chunk_text("Some text here.", page_num=7)
     assert all("text" in c and "page" in c and "chunk_index" in c for c in chunks)
     assert all(c["page"] == 7 for c in chunks)
 
-
 def test_chunk_index_is_sequential():
-    """chunk_index values must be 0-based and contiguous."""
-    long_text = "word " * (CHUNK_SIZE * 3)  # guaranteed multi-chunk
+    long_text = "word " * (CHUNK_SIZE * 3)
     chunks = chunk_text(long_text, page_num=1)
     assert len(chunks) > 1
     for i, chunk in enumerate(chunks):
         assert chunk["chunk_index"] == i
 
-
 def test_multi_chunk_text_overlaps():
-    """
-    With overlap > 0 the tail of chunk N should share tokens with the head of chunk N+1.
-    We verify this by asserting the total reconstructed tokens > len(original tokens),
-    which is only possible if overlap is actually applied.
-    """
-    enc = tiktoken.get_encoding("cl100k_base")
     long_text = "word " * (CHUNK_SIZE * 2)
     chunks = chunk_text(long_text, page_num=1)
     assert len(chunks) > 1
-    total_tokens = sum(len(enc.encode(c["text"])) for c in chunks)
-    original_tokens = len(enc.encode(long_text))
-    # With overlap, the sum of chunk tokens exceeds the original
+    total_tokens = sum(len(c["text"].split()) for c in chunks)
+    original_tokens = len(long_text.split())
     assert total_tokens > original_tokens
 
-
 def test_empty_text_produces_no_chunks():
-    """Empty string should yield an empty list (no tokens to encode)."""
     chunks = chunk_text("", page_num=1)
     assert chunks == []
 
-
 def test_chunk_text_preserves_page_num():
-    """page_num should be passed through unchanged regardless of value."""
     for page in (1, 42, 999):
         chunks = chunk_text("some content", page_num=page)
         assert all(c["page"] == page for c in chunks)
 
-
 def test_large_chunk_size_produces_single_chunk(monkeypatch):
-    """If CHUNK_SIZE covers the whole text, only one chunk is produced."""
-    import app
     monkeypatch.setattr(app, "CHUNK_SIZE", 10_000)
     monkeypatch.setattr(app, "CHUNK_OVERLAP", 0)
     text = "a short sentence."

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -173,7 +173,7 @@ def test_startup_slow_path_builds_and_saves(monkeypatch, tmp_path):
     monkeypatch.setattr(app, "load_pdf_chunks", lambda _path: fake_chunks)
     monkeypatch.setattr(app, "build_index", lambda chunks: fake_index)
     monkeypatch.setattr(app, "save_index", lambda idx, cks: save_calls.append((idx, cks)))
-    monkeypatch.setattr(app, "_get_encoder", lambda: None)   # skip tiktoken init print
+
 
     app.startup(force_rebuild=True)
 
@@ -202,7 +202,7 @@ def test_startup_slow_path_skips_precomputed_even_if_present(monkeypatch, tmp_pa
     monkeypatch.setattr(app, "load_pdf_chunks", lambda _: fresh_chunks)
     monkeypatch.setattr(app, "build_index", lambda _: fresh_index)
     monkeypatch.setattr(app, "save_index", lambda idx, cks: None)
-    monkeypatch.setattr(app, "_get_encoder", lambda: None)
+
 
     app.startup(force_rebuild=True)
 


### PR DESCRIPTION
# Fix Architecture Drift

Fix the "United Nations" of tokenizers, lingering OpenAI references in documentation, and the exception masking on startup.

## Proposed Changes

### Documentation
#### [MODIFY] SPEC.md
- Remove lines claiming the use of `OPENAI_API_KEY` and `text-embedding-3-small`.
- Update with the actual local embedding model: `all-MiniLM-L6-v2`.

### Application Logic & Dependencies
#### [MODIFY] app.py
- Drop the `tiktoken` dependency and the `cl100k_base` logic.
- Replace `chunk_text()` to use `get_embed_model().tokenizer` to perfectly align chunk tokens with the local embedding model's vocabulary.
- In `startup()`, trigger `get_anthropic()` explicitly inside the `try` block. If `ANTHROPIC_API_KEY` is completely missing, the `AuthenticationError` will correctly populate `_startup_error` before the server starts receiving requests.

#### [MODIFY] requirements.txt
- Remove `tiktoken`.

## Verification Plan
### Automated Tests
Run existing tests via `uv run --with-requirements requirements.txt pytest tests/ --ignore=tests/smoke -v`.

### Manual Verification
Ensure `app.py` can still chunk, embed, and start up successfully with the correct error messaging if `ANTHROPIC_API_KEY` is omitted.