### PR TITLE
fix(ci): use oci:// prefix for gh attestation verify

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -67,7 +67,7 @@ jobs:
 
           # Verify attestation — cryptographic proof this image was built from the expected commit
           declare -l FULL_IMAGE="ghcr.io/${{ github.repository }}@${DIGEST}"
-          gh attestation verify "${FULL_IMAGE}" --owner "${{ github.repository_owner }}" || {
+          gh attestation verify "oci://${FULL_IMAGE}" --owner "${{ github.repository_owner }}" || {
             echo "::error::Attestation verification failed for ${FULL_IMAGE}"
             exit 1
           }


### PR DESCRIPTION
## Summary

Fixes attestation verification in `deploy-test.yml` — `gh attestation verify` interprets its first argument as a local artifact path without the `oci://` prefix.

### Change

```diff
- gh attestation verify "${FULL_IMAGE}" --owner "..."
+ gh attestation verify "oci://${FULL_IMAGE}" --owner "..."
```

This was caught during the first manual test of PR #91.