### PR TITLE
fix(ci): use --repo instead of --owner for gh attestation verify

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -67,7 +67,7 @@ jobs:
 
           # Verify attestation — cryptographic proof this image was built from the expected commit
           declare -l FULL_IMAGE="ghcr.io/${{ github.repository }}@${DIGEST}"
-          gh attestation verify "oci://${FULL_IMAGE}" --owner "${{ github.repository_owner }}" || {
+          gh attestation verify "oci://${FULL_IMAGE}" --repo "${{ github.repository }}" || {
             echo "::error::Attestation verification failed for ${FULL_IMAGE}"
             exit 1
           }


### PR DESCRIPTION
## Summary

Fixes the HTTP 404 from `gh attestation verify` — `--owner` queries the org attestation endpoint which fails for user accounts.

### Root Cause

`gh attestation verify --owner DerekRoberts` calls:
```
GET /orgs/DerekRoberts/attestations/sha256:...
```
`DerekRoberts` is a user, not an org, so this returns 404.

### Fix

`--repo` accepts `OWNER/REPO` format and routes correctly for both users and orgs:
```diff
- gh attestation verify "oci://${FULL_IMAGE}" --owner "${{ github.repository_owner }}"
+ gh attestation verify "oci://${FULL_IMAGE}" --repo "${{ github.repository }}"
```

This was caught during the second manual test run after PR #92.