### PR TITLE
fix(ci): add attest-build-provenance step to generate GitHub attestations

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -113,6 +113,13 @@ jobs:
           build-args: |
             VERSION=sha-${{ steps.sha.outputs.commit }}
 
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
       - name: Output Status
         run: echo "Build successful for ${{ github.repository }} (Digest ${{ steps.build.outputs.digest }})"
 


### PR DESCRIPTION
## Summary

Fixes Deploy TEST failing with `HTTP 404` on `gh attestation verify`.

## Root Cause

`docker/build-push-action` with `provenance: true` creates **OCI attestations** stored in the registry manifest. These are _not_ the same as **GitHub Artifact Attestations** — the objects queryable via the GitHub API (`/repos/{owner}/{repo}/attestations/{digest}`) that `gh attestation verify` looks for.

Deploy TEST was resolving the image digest correctly (via the PR head SHA tag) but then 404ing because no GitHub-side attestation record existed for that digest.

## Fix

Added `actions/attest-build-provenance@v2` after the build step in `analysis.yml`. This creates the GitHub Artifact Attestation that `gh attestation verify` requires, with `push-to-registry: true` so the attestation is also embedded in the OCI manifest for belt-and-suspenders coverage.