### PR TITLE
feat: decouple query condenser and rename to CONDENSE_MODEL

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,7 +51,7 @@ _GITHUB_RAW_BASE = (
 )
 
 CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "claude-haiku-4-5-20251001")
-CONDENSER_MODEL = os.getenv("CONDENSER_MODEL", "claude-haiku-4-5-20251001")
+CONDENSE_MODEL = os.getenv("CONDENSE_MODEL", "claude-haiku-4-5-20251001")
 EMBED_MODEL = os.getenv("EMBED_MODEL", "all-MiniLM-L6-v2")
 CHUNK_SIZE = int(os.getenv("CHUNK_SIZE", 256))       # tokens per chunk
 CHUNK_OVERLAP = int(os.getenv("CHUNK_OVERLAP", 50))  # token overlap
@@ -367,7 +367,7 @@ async def condense_query(message: str, history: list[dict]) -> str:
 
     try:
         response = await client.messages.create(
-            model=CONDENSER_MODEL,
+            model=CONDENSE_MODEL,
             max_tokens=100,
             messages=[{"role": "user", "content": prompt}]
         )

--- a/tests/smoke/test_model_valid.py
+++ b/tests/smoke/test_model_valid.py
@@ -48,3 +48,26 @@ def test_claude_model_exists_and_responds():
 
     # Any valid response confirms the model is reachable
     assert response.content is not None
+
+
+def test_condense_model_exists_and_responds():
+    """
+    Send a minimal 1-token request to CONDENSE_MODEL.
+    """
+    from app import CONDENSE_MODEL
+
+    client = anthropic.Anthropic()
+    try:
+        response = client.messages.create(
+            model=CONDENSE_MODEL,
+            max_tokens=1,
+            messages=[{"role": "user", "content": "ping"}],
+        )
+    except anthropic.NotFoundError as exc:
+        pytest.fail(
+            f"CONDENSE_MODEL='{CONDENSE_MODEL}' does not exist in the Anthropic API.\n"
+            f"Update the default in app.py or set the CONDENSE_MODEL env var.\n"
+            f"Original error: {exc}"
+        )
+
+    assert response.content is not None


### PR DESCRIPTION
## Summary

Addresses #77 by strictly renaming `CONDENSER_MODEL` to `CONDENSE_MODEL` and ensuring the query condensation step is decoupled from the main response model. Removed all legacy fallbacks to keep the MVP clean.

## Changes
- [app.py](file:///home/derek/Repos/vexilon/app.py): Rename `CONDENSER_MODEL` to `CONDENSE_MODEL`.
- [test_model_valid.py](file:///home/derek/Repos/vexilon/tests/smoke/test_model_valid.py): Added smoke test for `CONDENSE_MODEL`.