### PR TITLE
refactor: use image digest in deploy-prod

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -12,11 +12,45 @@ jobs:
     environment: prod
     permissions:
       contents: read
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve and verify image
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Look up the PR that was squash-merged at this commit
+          # and get its head SHA, which is what the image was built from in CI.
+          PR_HEAD_SHA=$(gh api "/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            --jq '.[0].head.sha')
+          if [ -z "$PR_HEAD_SHA" ] || [ "$PR_HEAD_SHA" = "null" ]; then
+            echo "::error::No PR found for commit ${{ github.sha }}"
+            exit 1
+          fi
+          TAG="sha-${PR_HEAD_SHA}"
+
+          # Resolve tag to immutable digest — proves image was built by CI for this PR
+          declare -l IMAGE="ghcr.io/${{ github.repository }}:${TAG}"
+          DIGEST=$(skopeo inspect "docker://${IMAGE}" --format '{{.Digest}}')
+          if [ -z "$DIGEST" ]; then
+            echo "::error::Image not found in GHCR: ${IMAGE}"
+            exit 1
+          fi
+
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Verified: ${IMAGE} (${DIGEST})"
+
       - name: Push image-based stub to Hugging Face Space
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: ./.github/scripts/deploy.sh "sha-${{ github.sha }}" --prod
+        run: ./.github/scripts/deploy.sh "${{ steps.resolve.outputs.digest }}" --prod


### PR DESCRIPTION
## Summary

Fixes the PROD deployment workflow to correctly identify images by SHA using digests.

### Problem
The deploy-prod.yml workflow was using `github.sha` directly, which is the merge commit SHA on main. However, images in analysis.yml are built and tagged with `sha-<PR_HEAD_SHA>` (the original PR commit). This means the tag `sha-<merge_commit_sha>` may not exist in GHCR, causing deployments to fail.

### Solution
- Look up the PR head SHA from the merge commit using GitHub API
- Resolve the tag to an immutable digest using skopeo
- Pass the digest to deploy.sh (which correctly uses @ separator for digests)

This matches the pattern already working in deploy-test.yml.