### PR TITLE
fix: use relative paths for PDF download links for cross-environment compatibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -900,6 +900,8 @@ if __name__ == "__main__":
 
     # Build allowed_paths: allow labour_law directory for PDF downloads
     # Use relative path for cross-environment compatibility (local dev + Docker container)
+    # Note: This allows the entire directory rather than specific files for cross-environment
+    # compatibility. The directory only contains PDF files per project structure, so this is acceptable.
     allowed_paths = [str(LABOUR_LAW_DIR)]
 
     app.launch(


### PR DESCRIPTION
## Summary

Fixes PDF download links to work in both local development and Docker container by using relative paths instead of absolute filesystem paths.

## Changes

| File | Change |
|------|--------|
| `app.py` | Use relative paths for Gradio file serving |
| `app.py` | Add HTML escaping for display names |
| `app.py` | Update docstring to reflect HTML output |

## Problem

The original implementation used `pdf.absolute()` which returns environment-specific paths:

- **Local:** `/home/derek/Repos/vexilon/data/labour_law/file.pdf`
- **Container:** `/app/data/labour_law/file.pdf`

These absolute paths don't match the URL paths Gradio serves, so **downloads were completely broken in production**.

## Solution

Use relative paths that resolve correctly in both environments:

```diff
- file_path = str(pdf.absolute())
+ file_path = f"data/labour_law/{pdf.name}"
```

The generated URLs (`/gradio_api/file=data/labour_law/file.pdf`) now work in both local and container contexts.

## Security

- Added `html.escape()` to sanitize display names and prevent potential XSS
- `allowed_paths` now uses the directory path instead of specific file list (documented trade-off in code comments)

## Testing

- [x] Syntax validation passes
- [x] Path resolution verified for both environments
