### PR TITLE
fix: resolve infinite build hang and restore read-only cache security

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -34,7 +34,7 @@ WORKDIR /app
 
 # 1. Copy the virtualenv and model cache from the builder
 COPY --from=builder /app/.venv /app/.venv
-COPY --from=builder --chown=1001:1001 /app/hf_cache /app/hf_cache
+COPY --from=builder /app/hf_cache /app/hf_cache
 
 # 2. Copy application code and PDF assets
 COPY data/ ./data/

--- a/app.py
+++ b/app.py
@@ -289,10 +289,8 @@ def get_embed_model() -> "SentenceTransformer":
         # Stabilize CPU usage in shared-resource environments (HF Spaces/CI)
         # We only do this at RUNTIME. Doing this during BUILD causes infinite hangs.
         if os.getenv("HF_SPACE_ID") or os.getenv("EXTERNAL_CI"):
-            if "OMP_NUM_THREADS" not in os.environ:
-                os.environ["OMP_NUM_THREADS"] = "1"
-            if "MKL_NUM_THREADS" not in os.environ:
-                os.environ["MKL_NUM_THREADS"] = "1"
+            for var in ("OMP_NUM_THREADS", "MKL_NUM_THREADS"):
+                os.environ.setdefault(var, "1")
 
         print(f"[embed] Loading local embedding model '{EMBED_MODEL}'…")
         

--- a/app.py
+++ b/app.py
@@ -39,13 +39,6 @@ import tempfile
 if not os.getenv("HF_HOME"):
     os.environ["HF_HOME"] = str(Path("./hf_cache").absolute())
 
-# Stabilize CPU usage in shared-resource environments (HF Spaces/CI)
-# Prevents thread thrashing that leads to 10+ minute hang times.
-if "OMP_NUM_THREADS" not in os.environ:
-    os.environ["OMP_NUM_THREADS"] = "1"
-if "MKL_NUM_THREADS" not in os.environ:
-    os.environ["MKL_NUM_THREADS"] = "1"
-
 # ─── Third-party: Deferred Imports ───────────────────────────────────────────
 # (numpy, anthropic, faiss, sentence_transformers, gradio)
 # are imported inside functions to keep startup and test-loading fast.
@@ -293,15 +286,27 @@ _anthropic_client: "anthropic.AsyncAnthropic | None" = None
 def get_embed_model() -> "SentenceTransformer":
     global _embed_model
     if _embed_model is None:
+        # Stabilize CPU usage in shared-resource environments (HF Spaces/CI)
+        # We only do this at RUNTIME. Doing this during BUILD causes infinite hangs.
+        if os.getenv("HF_SPACE_ID") or os.getenv("EXTERNAL_CI"):
+            if "OMP_NUM_THREADS" not in os.environ:
+                os.environ["OMP_NUM_THREADS"] = "1"
+            if "MKL_NUM_THREADS" not in os.environ:
+                os.environ["MKL_NUM_THREADS"] = "1"
+
         print(f"[embed] Loading local embedding model '{EMBED_MODEL}'…")
+        
+        # Ensure we are truly offline to avoid lock-file permission errors 
+        # in the root-owned (read-only) hf_cache.
+        if os.getenv("TRANSFORMERS_OFFLINE") == "1":
+             os.environ["HF_HUB_OFFLINE"] = "1"
+
         from sentence_transformers import SentenceTransformer
 
         # Use the requested device (cpu) to avoid CUDA detection overhead.
-        # We rely on TRANSFORMERS_OFFLINE=1 (set in Containerfile) for production air-gapping.
         _embed_model = SentenceTransformer(EMBED_MODEL, device="cpu")
 
         # Sane limit for offset mapping (4096 is plenty for any single page).
-        # 100,000 was causing potential memory pressure and is far beyond the model's window.
         _embed_model.max_seq_length = MAX_EMBED_TOKENS
         if hasattr(_embed_model, "tokenizer"):
             _embed_model.tokenizer.model_max_length = MAX_EMBED_TOKENS


### PR DESCRIPTION
This PR fixes the regressions introduced in #238:\n\n1. **Restores Security**: Reverts the root-owned  to be read-only (chown removal).\n2. **Fixes Build Hang**: Moves the OMP/MKL thread pinning to runtime-only. This prevents the Docker build stage in HF Spaces from being throttled to a single core, which was causing the 'indefinite' build state.\n3. **Handles Permissions**: Adds explicit  logic to ensure the app doesn't attempt to create lock-files in the read-only cache directory.\n\nThe core performance fixes (token limit and volume mounts) are preserved to keep deployment times fast.