### PR TITLE
fix: increase token/input limits and add truncation warnings #215

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Input sanitization prevents prompt injection attacks by detecting and blocking m
 
 | Variable | Default | Description |
 |---|---|---|
-| `MAX_INPUT_LENGTH` | `2000` | Maximum characters per message |
+| `MAX_INPUT_LENGTH` | `10000` | Maximum characters per message |
 | `LOG_SUSPICIOUS_INPUTS` | `true` | Log flagged inputs for security review |
 
 The sanitization checks for 16+ prompt injection patterns including:

--- a/SPEC.md
+++ b/SPEC.md
@@ -228,7 +228,7 @@ To prevent prompt injection attacks, Vexilon implements input sanitization:
 
 - **Detection:** Regex-based pattern matching for 16+ known prompt injection patterns
 - **Patterns include:** `ignore all instructions`, `forget your rules`, `jailbreak`, `developer mode`, `sudo mode`, roleplay attempts, and other common injection techniques
-- **Length limits:** Maximum input length (default 2000 characters) to prevent buffer overflow attacks
+- **Length limits:** Maximum input length (default 10000 characters) to prevent buffer overflow attacks
 - **Logging:** Flagged inputs are logged for security monitoring (configurable)
 - **User feedback:** When input is flagged, users receive: "Your input was flagged for security review. Please try a different question."
 
@@ -475,7 +475,7 @@ Open `http://localhost:7860`.
 | `VERIFY_MODEL` | `claude-haiku-4-5-20251001` | Claude model for verification |
 | `RATE_LIMIT_PER_MINUTE` | `10` | Max requests per minute per client IP |
 | `RATE_LIMIT_PER_HOUR` | `100` | Max requests per hour per client IP |
-| `MAX_INPUT_LENGTH` | `2000` | Max characters per user message |
+| `MAX_INPUT_LENGTH` | `10000` | Max characters per user message |
 | `LOG_SUSPICIOUS_INPUTS` | `true` | Log flagged inputs for security review |
 
 ---

--- a/app.py
+++ b/app.py
@@ -1228,9 +1228,9 @@ def log_review(query: str, raw_response: str, review_output: str, score: int) ->
         writer.writerow(
             [
                 datetime.datetime.now().isoformat(),
-                query[:1000],  # Truncate long queries
-                raw_response[:2000],  # Truncate long responses
-                review_output[:4000],
+                query[:10000],  # Truncate long queries
+                raw_response[:16000],  # Truncate long responses
+                review_output[:16000],
                 score,
                 VEXILON_USERNAME,
             ]

--- a/app.py
+++ b/app.py
@@ -73,8 +73,8 @@ VERIFY_MODEL = os.getenv("VEXILON_VERIFY_MODEL", DEFAULT_MODEL_LLM)
 
 
 # Generation Limits (Tokens)
-RAG_MAX_TOKENS = 1536
-REVIEWER_MAX_TOKENS = 1536
+RAG_MAX_TOKENS = 4096
+REVIEWER_MAX_TOKENS = 4096
 
 # Brain: Local Embeddings (Search) + Cloud LLM (Claude)
 EMBED_MODEL = os.getenv("EMBED_MODEL", "BAAI/bge-small-en-v1.5")  # 512-token window
@@ -91,7 +91,7 @@ import re
 import logging
 
 # Input Sanitization (for prompt injection prevention)
-MAX_INPUT_LENGTH = int(os.getenv("MAX_INPUT_LENGTH", 2000))
+MAX_INPUT_LENGTH = int(os.getenv("MAX_INPUT_LENGTH", 10000))
 LOG_SUSPICIOUS_INPUTS = os.getenv("LOG_SUSPICIOUS_INPUTS", "true").lower() == "true"
 
 PROMPT_INJECTION_PATTERNS = [
@@ -131,7 +131,7 @@ def sanitize_input(user_input: str) -> tuple[str, bool]:
             injection_found = True
             if LOG_SUSPICIOUS_INPUTS:
                 logging.warning(
-                    f"[security] Prompt injection pattern detected: {pattern.pattern[:30]}..."
+                    f"[security] Prompt injection pattern detected: {pattern.pattern[:100]}..."
                 )
             break
 
@@ -1148,6 +1148,8 @@ async def rag_stream(
                 f"cache_create: {cache_created}, cache_read: {cache_read}, "
                 f"output: {usage.output_tokens}"
             )
+            if final.stop_reason == "max_tokens":
+                yield ("\n\n⚠️ Response truncated. Please ask for the rest of the answer.", "")
     except Exception as exc:
         yield (f"\n\n⚠️ API error: {exc}", "")
 
@@ -1226,9 +1228,9 @@ def log_review(query: str, raw_response: str, review_output: str, score: int) ->
         writer.writerow(
             [
                 datetime.datetime.now().isoformat(),
-                query[:500],  # Truncate long queries
-                raw_response[:1000],  # Truncate long responses
-                review_output[:2000],
+                query[:1000],  # Truncate long queries
+                raw_response[:2000],  # Truncate long responses
+                review_output[:4000],
                 score,
                 VEXILON_USERNAME,
             ]
@@ -1457,6 +1459,8 @@ async def rag_review_stream(
                 f"[rag] Tokens — input: {usage.input_tokens}, "
                 f"output: {usage.output_tokens}"
             )
+            if final.stop_reason == "max_tokens":
+                yield "\n\n⚠️ Response truncated. Please ask for the rest of the answer."
 
         # Bot B: Review the response if enabled
         if use_reviewer:


### PR DESCRIPTION
## Summary
This PR addresses issue #215 where bot responses were often cut short.

### Changes:
- Increased `RAG_MAX_TOKENS` from 1536 to 4096 to allow for longer, more detailed responses.
- Increased `REVIEWER_MAX_TOKENS` from 1536 to 4096 for more comprehensive senior rep reviews.
- Increased `MAX_INPUT_LENGTH` from 2000 to 10000 characters to support longer user queries and context pasting.
- Added proactive truncation warnings in `rag_stream` and `rag_review_stream` that trigger when the model reaches the token limit.
- Updated documentation (`SPEC.md`, `README.md`) and internal logging limits to reflect these changes.

These changes ensure that stewards get complete answers even for complex cases, and are clearly informed if a response is still too long for a single turn.