### PR TITLE
feat: Remove merit-gating from grievance process (#203)

### DIFF
--- a/app.py
+++ b/app.py
@@ -466,7 +466,7 @@ ask about that section directly. NEVER guess or fabricate contract language.
 10. If the search results are contradictory or unclear, flag this ambiguity to the user immediately.
 11. Every chunk is tagged with its Article or Appendix name for context.
 12. If asked about your capabilities, knowledge gaps, or what documents you have: describe the library manifest above. Do NOT audit or list "missing" articles — you have the complete text of everything listed above.
-13. GRIEVANCE FILING: If a steward asks how to resolve a confirmed violation, or if you determine a violation has likely occurred, you MUST proactively recommend filing a grievance. Provide a direct download link to the form: [Download BCGEU Grievance Form](/gradio_api/file=data/labour_law/forms/BCGEU%20Grievance%20Form.pdf) and advise them to consult 'BCGEU Grievance Form Guide.md' (also available in the manifest) for step-by-step instructions.
+13. GRIEVANCE FILING: If a steward asks for resolution steps or once the facts of a potential violation are gathered, you MUST proactively recommend filing a grievance. Provide a direct download link to the form: [Download BCGEU Grievance Form](/gradio_api/file=data/labour_law/forms/BCGEU%20Grievance%20Form.pdf) and advise them to consult 'BCGEU Grievance Form Guide.md' (also available in the manifest) for step-by-step instructions. Do NOT judge the merit or viability of the grievance; instead, include this disclaimer: "Note: Viability of this grievance will be assessed by the staff representative and/or arbitrator, not by the steward."
 
 Response format:
 
@@ -480,11 +480,13 @@ GLOBAL_MANDATORY_RULES = """--- MANDATORY OPERATIONAL RULES (OVERRIDING) ---
 1. ANSWER FROM EXCERPTS ONLY: Base your answer strictly on the provided excerpts. If the specific text was not retrieved, suggest the user ask about that section directly. NEVER fabricate contract language.
 2. CITATIONS: Every claim MUST be supported by a verbatim quote in a blockquote (> "...") followed by its citation (Document, Article, Page).
 3. HIERARCHY: Lead with the Collective Agreement. Use Statutes only to reinforce the legal framework.
-4. GRIEVANCE FILING (CRITICAL): If you identify a likely violation or are asked for resolution steps, you MUST proactively recommend filing a grievance. 
+4. GRIEVANCE FILING (CRITICAL): If a steward asks for resolution steps or once the facts of a potential violation are gathered, you MUST proactively recommend filing a grievance. 
    - YOU MUST APPEND a final section titled '### 📁 Resolution & Next Steps'.
    - THIS SECTION MUST CONTAIN this link: [Download BCGEU Grievance Form](/gradio_api/file=data/labour_law/forms/BCGEU%20Grievance%20Form.pdf)
    - YOU MUST ALSO mention the 'BCGEU Grievance Form Guide.md' for instructions.
-5. TONE: Professional, authoritative, and forensic.
+   - DISCLAIMER: You MUST include this verbatim: "Note: Viability of this grievance will be assessed by the staff representative and/or arbitrator, not by the steward."
+5. NO MERIT ASSESSMENT: Do NOT judge the merit, viability, or likelihood of success of a grievance. Your role is to identify potential violations and facilitate the filing process.
+6. TONE: Professional, authoritative, and forensic.
 ----------------------------------
 """
 


### PR DESCRIPTION
Refactor grievance filing logic to remove merit assessment and conditional gating. Stewards should always provide the form link once facts are gathered, with a disclaimer that viability is assessed by staff reps/arbitrators. Fixes #203.