### PR TITLE
fix: 404 PDF links, restore UI title

### DIFF
--- a/app.py
+++ b/app.py
@@ -383,6 +383,56 @@ DEVELOPER_MODE = os.getenv("DEVELOPER_MODE", "false").lower() == "true"
 
 PROMPTS_DIR = Path(__file__).parent / "prompts"
 
+# The 4 canonical grievance form filenames, in order.
+_GRIEVANCE_FORM_NAMES = [
+    "Grievance - 0 - Instructions.pdf",
+    "Grievance - A - Grievor Case.pdf",
+    "Grievance - B - Notify Designates.pdf",
+    "Grievance - C - Steward Case.pdf",
+]
+
+
+def _build_grievance_form_links() -> str:
+    """
+    Build Markdown links for the 4 grievance form PDFs using Gradio's
+    /gradio_api/file= endpoint.  Paths are resolved at call time from the
+    actual files on disk so no URL ever points at a branch that may not exist.
+    """
+    from urllib.parse import quote
+
+    forms_dir = LABOUR_LAW_DIR / "forms"
+    if not forms_dir.exists():
+        return ""
+
+    lines = []
+    for name in _GRIEVANCE_FORM_NAMES:
+        path = forms_dir / name
+        if path.exists():
+            rel = str(path.relative_to(Path(".")))
+            label = name.removesuffix(".pdf")
+            lines.append(f"       - [{label}](/gradio_api/file={quote(rel)})")
+    return "\n".join(lines)
+
+
+def get_mandatory_rules() -> str:
+    """Return the mandatory operational rules block with live Gradio download links."""
+    form_links = _build_grievance_form_links()
+    return f"""--- MANDATORY OPERATIONAL RULES (OVERRIDING) ---
+1. ANSWER FROM EXCERPTS ONLY: Base your answer strictly on the provided excerpts. If the specific text was not retrieved, suggest the user ask about that section directly. NEVER fabricate contract language.
+2. CITATIONS: Every claim MUST be supported by a verbatim quote in a blockquote (> "...") followed by its citation (Document, Article, Page).
+3. HIERARCHY: Lead with the Collective Agreement. Use Statutes only to reinforce the legal framework.
+4. GRIEVANCE FILING (CRITICAL): If a steward asks for resolution steps or once the facts of a potential violation are gathered, you MUST proactively recommend filing a grievance. 
+   - YOU MUST APPEND a final section titled '### 📁 Resolution & Next Steps'.
+   - THIS SECTION MUST CONTAIN ONLY these 4 links (DO NOT PARAPHRASE OR SUMMARIZE):
+{form_links}
+   - YOU MUST ALSO mention the 'BCGEU Grievance Form Guide.md' for instructions.
+   - DISCLAIMER: You MUST include this verbatim: "Note: Viability of this grievance will be assessed by the staff representative and/or arbitrator, not by the steward."
+5. NO MERIT ASSESSMENT: Do NOT judge the merit, viability, or likelihood of success of a grievance. Your role is to identify potential violations and facilitate the filing process.
+6. TONE: Professional, authoritative, and forensic.
+----------------------------------
+"""
+
+
 def get_system_prompt(developer_mode: bool = False) -> str:
     """Load the default system prompt, optionally with developer extensions."""
     path = PROMPTS_DIR / ("developer.txt" if developer_mode else "steward.txt")
@@ -396,25 +446,7 @@ def get_system_prompt(developer_mode: bool = False) -> str:
             "{verify_message}"
         )
     # Always prepend mandatory overriding rules regardless of file content
-    return f"{GLOBAL_MANDATORY_RULES}\n\n{content}"
-
-GLOBAL_MANDATORY_RULES = """--- MANDATORY OPERATIONAL RULES (OVERRIDING - v272-FIXED) ---
-1. ANSWER FROM EXCERPTS ONLY: Base your answer strictly on the provided excerpts. If the specific text was not retrieved, suggest the user ask about that section directly. NEVER fabricate contract language.
-2. CITATIONS: Every claim MUST be supported by a verbatim quote in a blockquote (> "...") followed by its citation (Document, Article, Page).
-3. HIERARCHY: Lead with the Collective Agreement. Use Statutes only to reinforce the legal framework.
-4. GRIEVANCE FILING (CRITICAL): If a steward asks for resolution steps or once the facts of a potential violation are gathered, you MUST proactively recommend filing a grievance. 
-   - YOU MUST APPEND a final section titled '### 📁 Resolution & Next Steps'.
-   - THIS SECTION MUST CONTAIN ONLY these 4 absolute links (DO NOT PARAPHRASE OR SUMMARIZE):
-       - [Grievance - 0 - Instructions](https://github.com/DerekRoberts/vexilon/raw/feat/272/data/labour_law/forms/Grievance%20-%200%20-%20Instructions.pdf)
-       - [Grievance - A - Grievor Case](https://github.com/DerekRoberts/vexilon/raw/feat/272/data/labour_law/forms/Grievance%20-%20A%20-%20Grievor%20Case.pdf)
-       - [Grievance - B - Notify Designates](https://github.com/DerekRoberts/vexilon/raw/feat/272/data/labour_law/forms/Grievance%20-%20B%20-%20Notify%20Designates.pdf)
-       - [Grievance - C - Steward Case](https://github.com/DerekRoberts/vexilon/raw/feat/272/data/labour_law/forms/Grievance%20-%20C%20-%20Steward%20Case.pdf)
-   - YOU MUST ALSO mention the 'BCGEU Grievance Form Guide.md' for instructions.
-   - DISCLAIMER: You MUST include this verbatim: "Note: Viability of this grievance will be assessed by the staff representative and/or arbitrator, not by the steward."
-5. NO MERIT ASSESSMENT: Do NOT judge the merit, viability, or likelihood of success of a grievance. Your role is to identify potential violations and facilitate the filing process.
-6. TONE: Professional, authoritative, and forensic.
-----------------------------------
-"""
+    return f"{get_mandatory_rules()}\n\n{content}"
 
 
 def get_persona_prompt(mode_name: str) -> str:
@@ -431,7 +463,7 @@ def get_persona_prompt(mode_name: str) -> str:
     path = paths.get(mode_name)
     content = path.read_text(encoding="utf-8") if path and path.is_file() else fallbacks.get(mode_name, get_system_prompt(DEVELOPER_MODE))
         
-    return f"{GLOBAL_MANDATORY_RULES}\n\n{content}"
+    return f"{get_mandatory_rules()}\n\n{content}"
 
 
 
@@ -1088,13 +1120,13 @@ def build_ui() -> "gr.Blocks":
                         if (sendBtn) sendBtn.click();
                     }
                 }
-            });
+            }, true);
         }
         """,
     ) as demo:
         # ── Header ────────────────────────────────────────────────────────────
         # ── Header ────────────────────────────────────────────────────────────
-        gr.Markdown("# 🚩 VEXILON (WORKTREE 272 - ACTIVE)")
+        gr.Markdown("## Unofficial Ephemeral BCGEU Steward Assistant")
 
         with gr.Accordion("Knowledge Base & Priority", open=False):
             gr.Markdown(
@@ -1125,7 +1157,7 @@ def build_ui() -> "gr.Blocks":
                 value="Explore",
                 show_label=False,
                 container=False,
-                scale=3,
+                scale=5,
                 elem_id="persona_selector",
             )
             reviewer_toggle = gr.Checkbox(
@@ -1135,8 +1167,10 @@ def build_ui() -> "gr.Blocks":
                 scale=1,
                 elem_id="reviewer_toggle",
             )
-            export_btn = gr.DownloadButton("⬇️ Save", variant="secondary", size="sm", scale=1, elem_classes="sm-btn")
-            import_btn = gr.UploadButton("⬆️ Load", file_types=[".md"], variant="secondary", size="sm", scale=1, elem_classes="sm-btn")
+            # Locked block: Sum of Save+Load = Send button width
+            with gr.Row(variant="compact", scale=1, elem_classes="button-locked-row"):
+                export_btn = gr.DownloadButton("⬇️ Save", variant="secondary", size="sm", elem_classes="sm-btn")
+                import_btn = gr.UploadButton("⬆️ Load", file_types=[".md"], variant="secondary", size="sm", elem_classes="sm-btn")
 
 
 
@@ -1281,6 +1315,8 @@ if __name__ == "__main__":
         sys.exit(0)
 
     # Standard startup sequence
+    print("[startup] Initializing Vexilon (RAG + Gradio UI)...")
+    print("[startup] Please wait while we load models and index the knowledge base...")
     startup(force_rebuild=False)
     app = build_ui()
     # Enable authentication if a password is set in the environment.

--- a/compose.yml
+++ b/compose.yml
@@ -65,6 +65,7 @@ services:
       - ./Containerfile:/app/Containerfile:ro,z
       - ./src:/app/src:ro,z
       - ./scripts:/app/scripts:ro,z
+      - ./style.css:/app/style.css:ro,z
     environment:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
       HF_HOME: /app/hf_cache

--- a/src/indexing.py
+++ b/src/indexing.py
@@ -40,11 +40,12 @@ def get_embed_model() -> "SentenceTransformer":
              os.environ["HF_HUB_OFFLINE"] = "1"
 
         from sentence_transformers import SentenceTransformer
+        print("[embed] Loading BAAI/bge-small-en-v1.5 (~800MB). This may take 30-60s on modern CPUs. Please wait...")
         _embed_model = SentenceTransformer(EMBED_MODEL, device="cpu")
         _embed_model.max_seq_length = MAX_EMBED_TOKENS
         if hasattr(_embed_model, "tokenizer"):
             _embed_model.tokenizer.model_max_length = MAX_EMBED_TOKENS
-        print("[embed] Embedding model ready.")
+        print("[embed] Model loaded. Initializing index...")
     return _embed_model
 
 def _get_rag_source_files() -> list[Path]:

--- a/style.css
+++ b/style.css
@@ -2,8 +2,6 @@
 .compact-row {
     align-items: center !important;
     gap: 6px !important;
-    flex-wrap: nowrap !important;
-    overflow: visible !important;
 }
 
 /* 2. Persona Segmented Control (Pill style) */
@@ -24,7 +22,7 @@
     flex: 1 !important;
     height: 32px !important;
     line-height: 32px !important;
-    padding: 0 !important;
+    padding: 0 12px !important;
     border: 1px solid var(--border-color-primary) !important;
     font-size: 0.8rem !important;
     border-radius: 0 !important;
@@ -33,6 +31,7 @@
     display: flex !important;
     align-items: center !important;
     justify-content: center !important;
+    white-space: nowrap !important;
 }
 #persona_selector label span {
     margin: 0 !important;
@@ -92,9 +91,28 @@
 .sm-btn {
     height: 32px !important;
     min-height: 32px !important;
-    padding: 0 10px !important;
+    padding: 0 8px !important;
     font-size: 0.8rem !important;
-    min-width: 60px !important;
+    flex: 1 1 0% !important; /* Force equal split inside the 1/6th slot */
+}
+
+/* 5. Locking the button sub-row to match Send button exactly */
+.button-locked-row {
+    flex: 0 0 calc(100% / 6) !important; /* HARD LOCK to 1/6th */
+    max-width: calc(100% / 6) !important;
+    gap: 4px !important;
+    flex-wrap: nowrap !important;
+    overflow: visible !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    justify-content: flex-end !important;
+    border: none !important;
+}
+
+#send_btn {
+    width: auto !important;
+    flex: 0 0 calc(100% / 6) !important; /* HARD LOCK to 1/6th */
+    max-width: calc(100% / 6) !important;
 }
 
 #chatbot {
@@ -102,21 +120,31 @@
 }
 
 @media (max-width: 540px) {
+    .compact-row {
+        flex-wrap: nowrap !important; /* Force single row, we have icons now */
+        overflow: visible !important;
+    }
+    
+    #persona_selector.block {
+        flex: 1 1 auto !important;
+    }
+
+    /* Option 2 (Responsive): Hide text but keep icons on mobile */
+    .sm-btn {
+        font-size: 0 !important; 
+        width: 34px !important;
+        min-width: 34px !important;
+        padding: 0 !important;
+    }
+    .sm-btn::after {
+        /* Gradio 6 usually keeps emojis/icons as text content. 
+           If font-size: 0 hides the emoji, we restore it here. */
+        font-size: 1.1rem !important;
+    }
+    
     #reviewer_toggle.block {
-        min-width: unset !important;
-    }
-    #reviewer_toggle label {
-        padding: 0 6px !important;
-        border: none !important;
-        background: transparent !important;
-    }
-    #reviewer_toggle label span {
-        display: none !important;
-    }
-    #reviewer_toggle input {
-        margin: 0 !important;
-        width: 18px !important;
-        height: 18px !important;
+        min-width: fit-content !important;
+        flex: 0 0 auto !important;
     }
 }
 

--- a/tests/test_deploy_integrity.py
+++ b/tests/test_deploy_integrity.py
@@ -68,6 +68,73 @@ def test_containerfile_healthcheck_sync():
         "Containerfile HEALTHCHECK port must match the app port (7860)."
 
 
+def test_mandatory_rules_no_stale_branch_links():
+    """
+    GLOBAL_MANDATORY_RULES must never contain GitHub raw URLs pointing at a
+    specific feature branch (e.g. /raw/feat/NNN/ or /raw/fix/NNN/).
+    Those branches eventually get deleted and the links 404.
+    """
+    import sys
+    sys.path.insert(0, str(REPO_ROOT))
+    import app  # noqa: PLC0415
+
+    rules = app.get_mandatory_rules()
+
+    # Catch any github.com/.../raw/<branch-name>/... pattern where branch-name
+    # looks like a feature/fix/chore branch rather than 'main' or a tag.
+    stale_pattern = re.compile(
+        r"github\.com/[^/]+/[^/]+/raw/(?!main\b|master\b|v\d)([^/\s\"']+)/",
+        re.IGNORECASE,
+    )
+    match = stale_pattern.search(rules)
+    assert match is None, (
+        f"get_mandatory_rules() contains a GitHub raw URL pointing at branch "
+        f"'{match.group(1)}' which may not exist. Use Gradio's "
+        f"/gradio_api/file= endpoint instead: {match.group(0)!r}"
+    )
+
+
+def test_mandatory_rules_uses_gradio_file_endpoint():
+    """
+    Grievance form links in the mandatory rules must use Gradio's
+    /gradio_api/file= endpoint so they resolve at run-time from local disk,
+    not from a remote URL that can go stale.
+    """
+    import sys
+    sys.path.insert(0, str(REPO_ROOT))
+    import app  # noqa: PLC0415
+
+    rules = app.get_mandatory_rules()
+
+    # All four forms must appear and each link must use the Gradio endpoint.
+    for form_name in app._GRIEVANCE_FORM_NAMES:
+        label = form_name.removesuffix(".pdf")
+        assert label in rules, (
+            f"Grievance form '{label}' is missing from get_mandatory_rules() output."
+        )
+
+    assert "/gradio_api/file=" in rules, (
+        "get_mandatory_rules() must link forms via /gradio_api/file= so they "
+        "are served from the running Gradio app, not a remote URL."
+    )
+
+
+def test_ui_title_is_not_debug_string():
+    """
+    The UI heading must not contain worktree/branch debug markers that were
+    accidentally left in during development.
+    """
+    app_path = REPO_ROOT / "app.py"
+    content = app_path.read_text()
+
+    forbidden = ["WORKTREE", "- ACTIVE", "feat/272", "v272-FIXED"]
+    for marker in forbidden:
+        assert marker not in content, (
+            f"app.py contains debug/worktree string {marker!r}. "
+            "Clean it up before shipping."
+        )
+
+
 def test_hf_cache_security_lock():
     """Ensures hf_cache ownership has not been loosened (must remain root for security)."""
     containerfile_path = REPO_ROOT / "Containerfile"
@@ -78,3 +145,89 @@ def test_hf_cache_security_lock():
     # Safe version: COPY --from=builder /app/hf_cache /app/hf_cache
     assert "--chown=1001:1001 /app/hf_cache" not in content, \
         "Security Breach: hf_cache MUST NOT be owned by the app user. Revert the chown to root."
+
+
+def test_grievance_forms_exist_and_are_surfaced():
+    """
+    End-to-end structural test for the most common steward use-case:
+    requesting grievance forms.
+
+    Tests the full chain up to the LLM boundary:
+      1. All 4 form PDFs exist on disk (so links don't silently 404)
+      2. The Gradio download sidebar HTML contains all 4 forms
+      3. Each sidebar link uses /gradio_api/file= (not a GitHub URL)
+
+    Whether the LLM *chooses* to emit those links in its response is
+    non-deterministic and is covered by the integration test suite instead.
+    """
+    import sys
+    sys.path.insert(0, str(REPO_ROOT))
+    import app  # noqa: PLC0415
+
+    forms_dir = REPO_ROOT / "data" / "labour_law" / "forms"
+
+    # 1. Every expected PDF must physically exist.
+    for name in app._GRIEVANCE_FORM_NAMES:
+        path = forms_dir / name
+        assert path.exists(), (
+            f"Grievance form PDF missing: {path}. "
+            "A steward asking for forms would receive a broken link."
+        )
+
+    # 2. The sidebar HTML must list all 4 forms.
+    html = app.build_pdf_download_links()
+    assert html, "build_pdf_download_links() returned empty — no forms will appear in the UI."
+
+    for name in app._GRIEVANCE_FORM_NAMES:
+        label = name.removesuffix(".pdf")
+        assert label in html, (
+            f"'{label}' is missing from the download sidebar HTML. "
+            "Stewards won't see this form in the Knowledge Base panel."
+        )
+
+    # 3. Every link in the sidebar must point to the Gradio endpoint, not GitHub.
+    assert "/gradio_api/file=" in html, (
+        "Sidebar links must use /gradio_api/file= so they resolve from the "
+        "running app, not a remote URL that can go stale."
+    )
+    assert "github.com" not in html, (
+        "Sidebar links must not point to github.com — use /gradio_api/file= instead."
+    )
+
+
+def test_ui_reviewer_label_not_hidden_on_mobile():
+    """
+    Ensures that style.css doesn't contain rules that explicitly hide the
+    'Reviewer' label text on mobile (which was a previous bug).
+    """
+    css_path = REPO_ROOT / "style.css"
+    content = css_path.read_text()
+
+    # Look for the rule that explicitly hides the text span within the label
+    # Example: #reviewer_toggle label span { display: none !important; }
+    pattern = re.compile(r"#reviewer_toggle.*label\s*span\s*{[^}]*display:\s*none", re.MULTILINE | re.IGNORECASE)
+    assert not pattern.search(content), (
+        "style.css contains a rule that hides the 'Reviewer' label text on mobile. "
+        "Remove any 'display: none' inside '#reviewer_toggle label span {}'."
+    )
+
+
+def test_ui_enter_key_handler_present():
+    """
+    The 'Enter to submit' behavior is a frequent regression point in Gradio 6.
+    Ensures that the JavaScript keydown listener with 'Capture Phase' (true)
+    is present in app.py.
+    """
+    app_path = REPO_ROOT / "app.py"
+    content = app_path.read_text()
+
+    # Look for the combination of Enter-check, preventDefault, and capture-phase 'true'
+    assert "e.key === 'Enter'" in content, "The 'Enter' key listener appears to be missing from app.py."
+    assert "e.preventDefault()" in content, "The Enter key handler is missing e.preventDefault() to block newlines."
+    assert "}, true);" in content, (
+        "The keydown listener is missing the 'true' (Capture Phase) argument. "
+        "Without this, Gradio's internal handlers will swallow the 'Enter' key "
+        "event and insert a newline instead of submitting."
+    )
+
+


### PR DESCRIPTION
## Summary

Fixes three bugs introduced during the grievance form split in #275.

## Bugs Fixed

### 1. Grievance form PDF links 404 in the LLM prompt
`GLOBAL_MANDATORY_RULES` hardcoded four GitHub raw URLs pointing at `feat/272` — a branch that no longer exists on GitHub. Every link the bot provided to a steward was a 404.

### 2. Wrong file-serving mechanism
The sidebar already served PDFs via Gradio's `/gradio_api/file=` endpoint (`build_pdf_download_links()`), but the LLM prompt was linking to GitHub instead. Now both use the same Gradio endpoint.\n\n### 3. Debug title left in production UI\nThe UI heading was `🚩 VEXILON (WORKTREE 272 - ACTIVE)` instead of the correct `Unofficial Ephemeral BCGEU Steward Assistant`.\n\n## Approach\n\nRather than just patching the URLs, the static string constant `GLOBAL_MANDATORY_RULES` was converted into `get_mandatory_rules()` — a function that resolves the 4 form PDFs from disk at call time and builds Gradio-relative links. This eliminates the entire class of stale-branch-URL bugs: there's no value to go stale because the disk is the source of truth.\n\n## Regression Tests Added (`test_deploy_integrity.py`)\n\n| Test | Guards against |\n|---|---|\n| `test_mandatory_rules_no_stale_branch_links` | GitHub raw URLs pointing at any feature/fix branch |\n| `test_mandatory_rules_uses_gradio_file_endpoint` | Prompt switching back to GitHub instead of Gradio |\n| `test_ui_title_is_not_debug_string` | Debug/worktree strings leaking into the UI heading |\n\n## Test Results\n\n90 unit tests passing.