### PR TITLE
fix(ci): restore version provenance build arg

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -106,6 +106,7 @@ jobs:
           build_context: .
           build_file: Containerfile
           tags: sha-${{ env.IMAGE_SHA }}
+          build_args: VERSION=sha-${{ env.IMAGE_SHA }}
 
   container_test:
     name: Container Smoke Test


### PR DESCRIPTION
## Summary

Restores the `build_args: VERSION=sha-...` configuration to the `bcgov/action-builder-ghcr` step in `pr-open.yml`.

During a recent migration to the new action builder, this argument was dropped, which caused the build provenance (the SHA in the footer of the UI) to fall back to 'unspecified-local' on test deployments.

This reinstates the missing argument.