### PR TITLE
feat: link to exact container image in footer

### DIFF
--- a/app.py
+++ b/app.py
@@ -1057,14 +1057,18 @@ EXAMPLE_QUESTIONS = [
 
 
 
+import html
+import urllib.parse
+_SAFE_VEXILON_VERSION = html.escape(VEXILON_VERSION)
+_URL_VEXILON_VERSION = urllib.parse.quote(VEXILON_VERSION)
 
 ATTRIBUTION_HTML = f"""
 <div style='text-align: center; color: #6b7280; font-size: 0.85rem; margin-top: 1rem;'>
-    <a href='{VEXILON_REPO_URL}' target='_blank' style='color: #005691; text-decoration: none;'>View code on GitHub</a>
+    <a href='{VEXILON_REPO_URL}' target='_blank' rel='noopener noreferrer' style='color: #005691; text-decoration: none;'>View code on GitHub</a>
     <span style='margin-left: 0.5rem; opacity: 0.7;'>•</span>
-    <a href='{VEXILON_REPO_URL}/blob/main/docs/PRIVACY.md' target='_blank' style='color: #008542; text-decoration: none;'>Privacy Policy (PIPA)</a>
+    <a href='{VEXILON_REPO_URL}/blob/main/docs/PRIVACY.md' target='_blank' rel='noopener noreferrer' style='color: #008542; text-decoration: none;'>Privacy Policy (PIPA)</a>
     <span style='margin-left: 0.5rem; opacity: 0.7;'>•</span>
-    <a href='{VEXILON_REPO_URL}/pkgs/container/vexilon/versions?filters%5Bversion_type%5D=tagged&query={VEXILON_VERSION}' target='_blank' style='color: #005691; text-decoration: none;'>{VEXILON_VERSION}</a>
+    <a href='{VEXILON_REPO_URL}/pkgs/container/vexilon/versions?filters%5Bversion_type%5D=tagged&query={_URL_VEXILON_VERSION}' target='_blank' rel='noopener noreferrer' style='color: #005691; text-decoration: none;'>{_SAFE_VEXILON_VERSION}</a>
 </div>
 """
 


### PR DESCRIPTION
## Summary

Updated the application footer to link directly to the specific container image on GitHub Packages.

Because GitHub's internal package ID cannot be known at build time, the link has been structured to query the GitHub Packages `versions` page pre-filtered to the specific SHA tag. This guarantees it points to the exact image while allowing it to be compiled dynamically at launch.