### PR TITLE
feat: harden CI gates to prevent merging failing tests

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -174,6 +174,7 @@ jobs:
           scan-type: "fs"
           scanners: "vuln,secret,misconfig"
           severity: "CRITICAL,HIGH"
+          exit-code: "1"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
@@ -182,10 +183,12 @@ jobs:
 
   results:
     name: Results
-    needs: [unit_tests, integration_tests, container_build, container_test, trivy]
+    needs: [check, unit_tests, integration_tests, container_build, container_test, trivy]
     if: always()
     runs-on: ubuntu-slim
     steps:
-      - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'canceled')
-        run: echo "At least one job has failed." && exit 1
-      - run: echo "Success!"
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'canceled')
+        run: |
+          echo "At least one required job has failed or was canceled."
+          exit 1
+      - run: echo "All critical checks passed or were intentionally skipped."


### PR DESCRIPTION
## Summary
This PR hardens the CI configuration to prevent merges when tests or security scans fail, addressing the issue where PRs (like bcgov/quickstart-openshift/pull/2667) were able to merge despite failing checks.

### Changes
- **Workflow Hardening**: Updated `Results` job in `pr-open.yml` to include `check` as a dependency and improved failure propagation logic.
- **Security Enforcement**: Added `exit-code: 1` to Trivy security scans to ensure critical vulnerabilities block the CI gate.

### Action Required
To fully prevent this issue, the repository administrator must:
1. Go to **Settings > Branches**.
2. Add/Edit a protection rule for the default branch (`main`).
3. Enable **Require status checks to pass before merging**.
4. Explicitly add **`Results`** as a required status check.