### PR TITLE
chore: optimize compose configuration with modular anchors

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -62,9 +62,20 @@ jobs:
             exit 1
           fi
 
+  compose_validation:
+    name: Compose Validation
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Validate Compose File
+        run: podman compose config
+
   tests:
     name: Tests and Analysis
-    needs: [check, cache_validation]
+    needs: [check, cache_validation, compose_validation]
     if: needs.check.outputs.triggered == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -32,50 +32,27 @@ jobs:
         with:
           triggers: '["./Containerfile", "./pyproject.toml", "./app.py", "./vexilon/", "./scripts/", "./prompts/", "./data/", "./tests/", "./.github/workflows/"]'
 
-  cache_validation:
-    name: Validate FAISS Cache
+  validate:
+    name: Validate and Scan
     needs: [check]
     if: needs.check.outputs.triggered == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           lfs: true
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.14'
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Validate Cache Manifest
+      - name: Containerized Validation & Security Scan
+        env:
+          VEXILON_VERSION: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          echo "Validating FAISS cache against source files..."
-          if ! uv run scripts/generate_cache_manifest.py validate; then
-            echo ""
-            echo "ERROR: Cache is out of sync with data/labour_law/ directory."
-            echo "Run 'python scripts/generate_cache_manifest.py' to regenerate."
-            exit 1
-          fi
-
-  compose_validation:
-    name: Compose Validation
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Validate Compose File
-        run: podman compose config
+          podman compose config
+          podman compose run --rm cache-validator
+          podman compose run --rm security-auditor
 
   tests:
     name: Tests and Analysis
-    needs: [check, cache_validation, compose_validation]
+    needs: [check, validate]
     if: needs.check.outputs.triggered == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -94,10 +71,13 @@ jobs:
           language: python
           python_version: "3.14"
           dir: .
-          # Consistent test execution via podman-compose
+          # Consistent test execution via podman-compose with SonarCloud artifacts
           commands: |
+            export VEXILON_VERSION=${{ github.event.pull_request.head.sha || github.sha }}
             export ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY || 'sk-dummy-key-for-predictability' }}
-            podman compose run --rm tests
+            mkdir -p reports
+            podman compose run --rm -v ./reports:/app/reports tests \
+              sh -c "uv run pytest --junitxml=reports/junit.xml --cov=vexilon --cov-report=xml:reports/coverage.xml tests/test_*.py tests/integration/ -v"
           triggers: '["./Containerfile", "./pyproject.toml", "./app.py", "./vexilon/", "./scripts/", "./prompts/", "./data/", "./tests/", "./.github/workflows/"]'
           sonar_token: ${{ secrets.SONAR_TOKEN }}
 

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -32,8 +32,8 @@ jobs:
         with:
           triggers: '["./Containerfile", "./pyproject.toml", "./app.py", "./vexilon/", "./scripts/", "./prompts/", "./data/", "./tests/", "./.github/workflows/"]'
 
-  validate:
-    name: Validate and Scan
+  cache_validation:
+    name: Validate FAISS Cache
     needs: [check]
     if: needs.check.outputs.triggered == 'true'
     runs-on: ubuntu-24.04
@@ -42,17 +42,36 @@ jobs:
         uses: actions/checkout@v6
         with:
           lfs: true
-      - name: Containerized Validation & Security Scan
-        env:
-          VEXILON_VERSION: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+      - name: Validate Cache Manifest
         run: |
-          podman compose config
-          podman compose run --rm cache-validator
-          podman compose run --rm security-auditor
+          echo "Validating FAISS cache against source files..."
+          if ! uv run scripts/generate_cache_manifest.py validate; then
+            echo ""
+            echo "ERROR: Cache is out of sync with data/labour_law/ directory."
+            echo "Run 'python scripts/generate_cache_manifest.py' to regenerate."
+            exit 1
+          fi
+
+  compose_validation:
+    name: Compose Validation
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Validate Compose File
+        run: podman compose config
 
   tests:
     name: Tests and Analysis
-    needs: [check, validate]
+    needs: [check, cache_validation, compose_validation]
     if: needs.check.outputs.triggered == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -71,13 +90,10 @@ jobs:
           language: python
           python_version: "3.14"
           dir: .
-          # Consistent test execution via podman-compose with SonarCloud artifacts
+          # Consistent test execution via podman-compose
           commands: |
-            export VEXILON_VERSION=${{ github.event.pull_request.head.sha || github.sha }}
             export ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY || 'sk-dummy-key-for-predictability' }}
-            mkdir -p reports
-            podman compose run --rm -v ./reports:/app/reports tests \
-              sh -c "uv run pytest --junitxml=reports/junit.xml --cov=vexilon --cov-report=xml:reports/coverage.xml tests/test_*.py tests/integration/ -v"
+            podman compose run --rm tests
           triggers: '["./Containerfile", "./pyproject.toml", "./app.py", "./vexilon/", "./scripts/", "./prompts/", "./data/", "./tests/", "./.github/workflows/"]'
           sonar_token: ${{ secrets.SONAR_TOKEN }}
 

--- a/Containerfile
+++ b/Containerfile
@@ -94,7 +94,7 @@ ENV VEXILON_VERSION=$VERSION
 
 EXPOSE 7860
 
-HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=30s --start-period=30s --retries=3 \
   CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:7860')" || exit 1
 
 CMD ["/app/scripts/startup.sh"]

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ Docker deployments.
 
 ### Prerequisites
 
-- **Container Engine**: [Podman](https://podman.io/docs/installation) (recommended) or [Docker](https://docs.docker.com/get-docker/) — **must include Compose support**
+- **Container Engine**: [Podman](https://podman.io/docs/installation) (recommended) or [Docker](https://docs.docker.com/get-docker/)
+- **Compose**: `podman compose` (built-in) or [Docker Compose V2](https://docs.docker.com/compose/) plugin
 - **Anthropic API key**: An active key exported as `ANTHROPIC_API_KEY`
 
 ### Run

--- a/README.md
+++ b/README.md
@@ -91,15 +91,15 @@ Docker deployments.
 
 ### Run
 
+> [!TIP]
+> **Docker users**: `docker compose` can be used as a drop-in replacement for `podman-compose` in all examples below.
+
 **1. Production Smoke Test (Immutable Code)**
 Run the app exactly as it will behave in production. Changes to your local files **will not** be reflected.
 
 ```bash
 export ANTHROPIC_API_KEY=<YOUR_ANTHROPIC_API_KEY>
-# Podman
 podman-compose up --build
-# Docker
-docker compose up --build
 ```
 
 **2. Local Development (Live Reload)**
@@ -107,10 +107,7 @@ Run the **`watch`** service to enable hot-reloading. When you modify `app.py`, `
 
 ```bash
 export ANTHROPIC_API_KEY=<YOUR_ANTHROPIC_API_KEY>
-# Podman
 podman-compose up --build watch
-# Docker
-docker compose up --build watch
 ```
 
 The container uses a multi-stage build and pre-indexes the agreement at build time for zero-downtime startup.
@@ -307,35 +304,20 @@ Vexilon uses a **Quality Gate** pattern in `compose.yml` — the app will not st
 uv run pytest tests/ --ignore=tests/integration --ignore=tests/smoke
 
 # Run full suite (unit + integration) inside the memory-capped container
-# Podman
 podman-compose run --rm tests
-# Docker
-docker compose run --rm tests
 
 # Gated startup — tests must pass before Vexilon launches
 export ANTHROPIC_API_KEY=<YOUR_ANTHROPIC_API_KEY>
-# Podman
 podman-compose up
-# Docker
-docker compose up
 
 # Live Development — launch with hot-reload and volumes
-# Podman
 podman-compose up watch
-# Docker
-docker compose up watch
 
 # Skip the gate — useful for rapid UI iteration (no volumes)
-# Podman
 podman-compose up vexilon
-# Docker
-docker compose up vexilon
 
 # Smoke tests — verifies real Anthropic API connectivity
-# Podman
 podman-compose run --rm tests sh -c "uv run --no-sync pytest tests/smoke/ -v"
-# Docker
-docker compose run --rm tests sh -c "uv run --no-sync pytest tests/smoke/ -v"
 ````
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -85,9 +85,8 @@ Docker deployments.
 
 ### Prerequisites
 
-- [Podman](https://podman.io/docs/installation) / [Docker](https://docs.docker.com/get-docker/)
-- [Podman Compose](https://github.com/containers/podman-compose) / [Docker Compose V2](https://docs.docker.com/compose/)
-- An [Anthropic API key](https://console.anthropic.com/) (`ANTHROPIC_API_KEY`)
+- **Container Engine**: [Podman](https://podman.io/docs/installation) (recommended) or [Docker](https://docs.docker.com/get-docker/)
+- **Anthropic API key**: An active key exported as `ANTHROPIC_API_KEY`
 
 ### Run
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ Docker deployments.
 
 ### Prerequisites
 
-- [Podman](https://podman.io/docs/installation) + [Podman Compose](https://github.com/containers/podman-compose)
+- [Podman](https://podman.io/docs/installation) / [Docker](https://docs.docker.com/get-docker/)
+- [Podman Compose](https://github.com/containers/podman-compose) / [Docker Compose V2](https://docs.docker.com/compose/)
 - An [Anthropic API key](https://console.anthropic.com/) (`ANTHROPIC_API_KEY`)
 
 ### Run
@@ -95,7 +96,10 @@ Run the app exactly as it will behave in production. Changes to your local files
 
 ```bash
 export ANTHROPIC_API_KEY=<YOUR_ANTHROPIC_API_KEY>
+# Podman
 podman-compose up --build
+# Docker
+docker compose up --build
 ```
 
 **2. Local Development (Live Reload)**
@@ -103,7 +107,10 @@ Run the **`watch`** service to enable hot-reloading. When you modify `app.py`, `
 
 ```bash
 export ANTHROPIC_API_KEY=<YOUR_ANTHROPIC_API_KEY>
+# Podman
 podman-compose up --build watch
+# Docker
+docker compose up --build watch
 ```
 
 The container uses a multi-stage build and pre-indexes the agreement at build time for zero-downtime startup.
@@ -300,20 +307,35 @@ Vexilon uses a **Quality Gate** pattern in `compose.yml` — the app will not st
 uv run pytest tests/ --ignore=tests/integration --ignore=tests/smoke
 
 # Run full suite (unit + integration) inside the memory-capped container
+# Podman
 podman-compose run --rm tests
+# Docker
+docker compose run --rm tests
 
 # Gated startup — tests must pass before Vexilon launches
 export ANTHROPIC_API_KEY=<YOUR_ANTHROPIC_API_KEY>
+# Podman
 podman-compose up
+# Docker
+docker compose up
 
 # Live Development — launch with hot-reload and volumes
+# Podman
 podman-compose up watch
+# Docker
+docker compose up watch
 
 # Skip the gate — useful for rapid UI iteration (no volumes)
+# Podman
 podman-compose up vexilon
+# Docker
+docker compose up vexilon
 
 # Smoke tests — verifies real Anthropic API connectivity
+# Podman
 podman-compose run --rm tests sh -c "uv run --no-sync pytest tests/smoke/ -v"
+# Docker
+docker compose run --rm tests sh -c "uv run --no-sync pytest tests/smoke/ -v"
 ````
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -90,11 +90,20 @@ Docker deployments.
 
 ### Run
 
-**Run the production-optimized container:**
+**1. Production Smoke Test (Immutable Code)**
+Run the app exactly as it will behave in production. Changes to your local files **will not** be reflected.
 
 ```bash
 export ANTHROPIC_API_KEY=<YOUR_ANTHROPIC_API_KEY>
 podman-compose up --build
+```
+
+**2. Local Development (Live Reload)**
+Run the **`watch`** service to enable hot-reloading. When you modify `app.py`, `style.css`, or the `vexilon/` directory, the container will automatically refresh.
+
+```bash
+export ANTHROPIC_API_KEY=<YOUR_ANTHROPIC_API_KEY>
+podman-compose up --build watch
 ```
 
 The container uses a multi-stage build and pre-indexes the agreement at build time for zero-downtime startup.
@@ -297,7 +306,10 @@ podman-compose run --rm tests
 export ANTHROPIC_API_KEY=<YOUR_ANTHROPIC_API_KEY>
 podman-compose up
 
-# Skip the gate — useful for rapid UI iteration
+# Live Development — launch with hot-reload and volumes
+podman-compose up watch
+
+# Skip the gate — useful for rapid UI iteration (no volumes)
 podman-compose up vexilon
 
 # Smoke tests — verifies real Anthropic API connectivity

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Docker deployments.
 
 ### Prerequisites
 
-- **Container Engine**: [Podman](https://podman.io/docs/installation) (recommended) or [Docker](https://docs.docker.com/get-docker/)
+- **Container Engine**: [Podman](https://podman.io/docs/installation) (recommended) or [Docker](https://docs.docker.com/get-docker/) — **must include Compose support**
 - **Anthropic API key**: An active key exported as `ANTHROPIC_API_KEY`
 
 ### Run

--- a/README.md
+++ b/README.md
@@ -92,14 +92,14 @@ Docker deployments.
 ### Run
 
 > [!TIP]
-> **Docker users**: `docker compose` can be used as a drop-in replacement for `podman-compose` in all examples below.
+> **Docker users**: `docker compose` can be used as a drop-in replacement for `podman compose` in all examples below.
 
 **1. Production Smoke Test (Immutable Code)**
 Run the app exactly as it will behave in production. Changes to your local files **will not** be reflected.
 
 ```bash
 export ANTHROPIC_API_KEY=<YOUR_ANTHROPIC_API_KEY>
-podman-compose up --build
+podman compose up --build
 ```
 
 **2. Local Development (Live Reload)**
@@ -107,7 +107,7 @@ Run the **`watch`** service to enable hot-reloading. When you modify `app.py`, `
 
 ```bash
 export ANTHROPIC_API_KEY=<YOUR_ANTHROPIC_API_KEY>
-podman-compose up --build watch
+podman compose up --build watch
 ```
 
 The container uses a multi-stage build and pre-indexes the agreement at build time for zero-downtime startup.
@@ -304,20 +304,20 @@ Vexilon uses a **Quality Gate** pattern in `compose.yml` — the app will not st
 uv run pytest tests/ --ignore=tests/integration --ignore=tests/smoke
 
 # Run full suite (unit + integration) inside the memory-capped container
-podman-compose run --rm tests
+podman compose run --rm tests
 
 # Gated startup — tests must pass before Vexilon launches
 export ANTHROPIC_API_KEY=<YOUR_ANTHROPIC_API_KEY>
-podman-compose up
+podman compose up
 
 # Live Development — launch with hot-reload and volumes
-podman-compose up watch
+podman compose up watch
 
 # Skip the gate — useful for rapid UI iteration (no volumes)
-podman-compose up vexilon
+podman compose up vexilon
 
 # Smoke tests — verifies real Anthropic API connectivity
-podman-compose run --rm tests sh -c "uv run --no-sync pytest tests/smoke/ -v"
+podman compose run --rm tests sh -c "uv run --no-sync pytest tests/smoke/ -v"
 ````
 
 > [!NOTE]

--- a/compose.yml
+++ b/compose.yml
@@ -86,13 +86,6 @@ services:
       PYTHONPATH: "/app"
     command: python scripts/build_index.py
 
-  # ── Troubleshooting Version ────────────────────────────────────────────────
-  # This service REUSES vexilon but strips the dependencies
-  app:
-    extends: vexilon
-    profiles: ["app"]
-    depends_on: [] # Overrides and removes default dependencies from 'vexilon'
-
   # ── Fast Development ───────────────────────────────────────────────────
   # Builds from source with live reload. Loads pre-computed index if available.
   dev:

--- a/compose.yml
+++ b/compose.yml
@@ -88,7 +88,7 @@ services:
 
   # ── Fast Development ───────────────────────────────────────────────────
   # Builds from source with live reload and polling enabled for Podman.
-  dev:
+  watch:
     <<: *service-defaults
     extends: vexilon
     build:

--- a/compose.yml
+++ b/compose.yml
@@ -10,23 +10,30 @@ x-common-env: &common-env
   HF_HUB_OFFLINE: "1"
   HF_TOKEN_PATH: /dev/null # Prevent HuggingFace token lookup permission errors
   PATH: "/app/.venv/bin:/app/:$PATH"
+  PYTHONPATH: "/app"
   TRANSFORMERS_OFFLINE: "1"
+  EMBED_MODEL: /app/hf_cache
 
 # Reusable build configuration
 x-common-build: &common-build
   context: .
   dockerfile: Containerfile
 
-# Balanced source mounting: Root is RO for safety, Cache is RW for persistence
-x-source-volumes: &source-volumes
-  - .:/app:ro,z
-  - ./.pdf_cache:/app/.pdf_cache:z
+# Standard service boilerplate: Resource limits and Volumes
+x-service-defaults: &service-defaults
+  mem_limit: *MEM_LIMIT
+  memswap_limit: *MEM_LIMIT
+  volumes:
+    - .:/app:ro,z
+    - ./.pdf_cache:/app/.pdf_cache:z
+    - /app/.venv # Prevents host mount from burying the container's installed packages
 
 services:
 
   # ── Vexilon app ───────────────────────────────────────────────────────────────
   # Production-ready entry point gated by integration tests.
   vexilon:
+    <<: *service-defaults
     build: *common-build
     environment:
       <<: *common-env
@@ -43,26 +50,18 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
-    mem_limit: *MEM_LIMIT
-    memswap_limit: *MEM_LIMIT # Match mem_limit to disable swap and prevent host thrashing
     depends_on:
       tests:
         condition: service_completed_successfully
-    volumes:
-      - ./.pdf_cache:/app/.pdf_cache:z
 
   # ── Testing ──────────────────────────────────────────────────────────────────
   # Run with: podman-compose run --rm tests
   tests:
+    <<: *service-defaults
     build:
       <<: *common-build
       target: test_builder
-    mem_limit: *MEM_LIMIT
-    memswap_limit: *MEM_LIMIT # Match mem_limit to disable swap and prevent host thrashing
-    volumes: *source-volumes
-    environment:
-      <<: *common-env
-      EMBED_MODEL: /app/hf_cache
+    environment: *common-env
     command: sh -c "uv run --no-sync python -m pytest tests/test_*.py tests/integration/ -v"
     depends_on:
       index-refresh:
@@ -71,19 +70,17 @@ services:
   # ── Cache Refresh ────────────────────────────────────────────────────────────
   # Run with: podman-compose run --rm index-refresh
   index-refresh:
+    <<: *service-defaults
     build:
       <<: *common-build
       target: builder
-    mem_limit: *MEM_LIMIT
-    memswap_limit: *MEM_LIMIT # Match mem_limit to disable swap and prevent host thrashing
-    volumes: *source-volumes
-    environment:
-      <<: *common-env
+    environment: *common-env
     command: python scripts/build_index.py
 
   # ── Fast Development ───────────────────────────────────────────────────
-  # Builds from source with live reload. Loads pre-computed index if available.
+  # Builds from source with live reload.
   dev:
+    <<: *service-defaults
     extends: vexilon
     build:
       target: builder
@@ -91,5 +88,4 @@ services:
     environment:
       <<: *common-env
       WATCHFILES_FORCE_POLLING: "true" # Force polling for reliable reload in Podman
-    volumes: *source-volumes
     command: sh -c "uv sync --frozen && uv run gradio app.py --watch-dirs ."

--- a/compose.yml
+++ b/compose.yml
@@ -67,7 +67,7 @@ services:
     build:
       <<: *common-build
       target: test_builder
-    volumes: *dev-volumes
+    volumes: *dev-volumes # Overrides x-service-defaults
     environment: *common-env
     command: sh -c "uv run --no-sync python -m pytest tests/test_*.py tests/integration/ -v"
     depends_on:

--- a/compose.yml
+++ b/compose.yml
@@ -7,10 +7,11 @@ x-var:
 # Reusable environment for all services
 x-common-env: &common-env
   ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
-  TRANSFORMERS_OFFLINE: "1"
   HF_HOME: /app/hf_cache
   HF_HUB_OFFLINE: "1"
   HF_TOKEN_PATH: /dev/null # Prevent HuggingFace token lookup permission errors
+  PATH: "/app/.venv/bin:/app/:$PATH"
+  TRANSFORMERS_OFFLINE: "1"
 
 # Reusable build configuration
 x-common-build: &common-build
@@ -33,8 +34,7 @@ services:
       VEXILON_USERNAME: ${VEXILON_USERNAME:-admin}
       VEXILON_PASSWORD: ${VEXILON_PASSWORD:-}
       PORT: *PORT
-    ports:
-      - "7860:7860"
+    ports: ["7860:7860"]
     cap_drop: [ALL]
     tmpfs: [/tmp]
     healthcheck:
@@ -64,7 +64,6 @@ services:
     environment:
       <<: *common-env
       EMBED_MODEL: /app/hf_cache
-      PYTHONPATH: "/app"
     command: sh -c "uv run --no-sync python -m pytest tests/test_*.py tests/integration/ -v"
     depends_on:
       index-refresh:
@@ -81,8 +80,6 @@ services:
     volumes: *source-volumes
     environment:
       <<: *common-env
-      PATH: "/app/.venv/bin:$PATH"
-      PYTHONPATH: "/app"
     command: python scripts/build_index.py
 
   # ── Fast Development ───────────────────────────────────────────────────
@@ -94,7 +91,6 @@ services:
     profiles: ["dev"]
     environment:
       <<: *common-env
-      PATH: "/app/.venv/bin:$PATH"
       WATCHFILES_FORCE_POLLING: "true" # Force polling for reliable reload in Podman
     volumes: *source-volumes
     command: sh -c "uv sync --frozen && uv run gradio app.py --watch-dirs ."

--- a/compose.yml
+++ b/compose.yml
@@ -2,7 +2,6 @@
 x-var:
   - &PORT "7860"
   - &MEM_LIMIT 3g
-  - &MEM_LIMIT_REFRESH 2g
 
 # Reusable environment for all services
 x-common-env: &common-env
@@ -75,8 +74,8 @@ services:
     build:
       <<: *common-build
       target: builder
-    mem_limit: *MEM_LIMIT_REFRESH
-    memswap_limit: *MEM_LIMIT_REFRESH
+    mem_limit: *MEM_LIMIT
+    memswap_limit: *MEM_LIMIT # Match mem_limit to disable swap and prevent host thrashing
     volumes: *source-volumes
     environment:
       <<: *common-env

--- a/compose.yml
+++ b/compose.yml
@@ -92,7 +92,7 @@ services:
     <<: *service-defaults
     build:
       <<: *common-build
-      target: builder
+      target: test_builder
     volumes: *dev-volumes
     environment: *common-env
     command: python scripts/generate_cache_manifest.py validate
@@ -103,7 +103,7 @@ services:
     <<: *service-defaults
     build:
       <<: *common-build
-      target: builder
+      target: test_builder
     environment: *common-env
     command: sh -c "uv run --no-sync bandit -r vexilon/ scripts/ app.py"
 

--- a/compose.yml
+++ b/compose.yml
@@ -16,17 +16,10 @@ x-common-build: &common-build
   context: .
   dockerfile: Containerfile
 
-# Explicit source mounting (avoiding .git and system junk)
+# Balanced source mounting: Root is RO for safety, Cache is RW for persistence
 x-source-volumes: &source-volumes
-  - ./app.py:/app/app.py:ro,z
-  - ./style.css:/app/style.css:ro,z
-  - ./tests:/app/tests:ro,z
-  - ./data:/app/data:ro,z
-  - ./vexilon:/app/vexilon:ro,z
-  - ./scripts:/app/scripts:ro,z
+  - .:/app:ro,z
   - ./.pdf_cache:/app/.pdf_cache:z
-  - ./pyproject.toml:/app/pyproject.toml:ro,z
-  - ./uv.lock:/app/uv.lock:ro,z
 
 services:
 

--- a/compose.yml
+++ b/compose.yml
@@ -92,10 +92,11 @@ services:
     <<: *service-defaults
     extends: vexilon
     build:
-      target: builder
+      <<: *common-build
+      target: test_builder
     profiles: ["dev"]
     volumes: *dev-volumes
     environment:
       <<: *common-env
       WATCHFILES_FORCE_POLLING: "true"
-    command: sh -c "uv sync --frozen && uv run gradio app.py --watch-dirs ."
+    command: uv run --no-sync gradio app.py --watch-dirs .

--- a/compose.yml
+++ b/compose.yml
@@ -8,6 +8,7 @@ x-var:
 x-common-env: &common-env
   ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
   TRANSFORMERS_OFFLINE: "1"
+  HF_HOME: /app/hf_cache
   HF_HUB_OFFLINE: "1"
   HF_TOKEN_PATH: /dev/null # Prevent HuggingFace token lookup permission errors
 
@@ -62,7 +63,6 @@ services:
     volumes: *source-volumes
     environment:
       <<: *common-env
-      HF_HOME: /app/hf_cache
       EMBED_MODEL: /app/hf_cache
       PYTHONPATH: "/app"
     command: sh -c "uv run --no-sync python -m pytest tests/test_*.py tests/integration/ -v"
@@ -81,7 +81,6 @@ services:
     volumes: *source-volumes
     environment:
       <<: *common-env
-      HF_HOME: /app/hf_cache
       PATH: "/app/.venv/bin:$PATH"
       PYTHONPATH: "/app"
     command: python scripts/build_index.py
@@ -95,7 +94,6 @@ services:
     profiles: ["dev"]
     environment:
       <<: *common-env
-      HF_HOME: /app/hf_cache
       PATH: "/app/.venv/bin:$PATH"
     volumes: *source-volumes
     command: sh -c "uv sync --frozen && uv run gradio app.py --watch-dirs ."

--- a/compose.yml
+++ b/compose.yml
@@ -86,6 +86,27 @@ services:
     environment: *common-env
     command: python scripts/build_index.py
 
+  # ── Cache Validator ──────────────────────────────────────────────────────────
+  # Validates that the index is in sync with source files.
+  cache-validator:
+    <<: *service-defaults
+    build:
+      <<: *common-build
+      target: builder
+    volumes: *dev-volumes
+    environment: *common-env
+    command: python scripts/generate_cache_manifest.py validate
+
+  # ── Security Auditor ────────────────────────────────────────────────────────
+  # Scans for security vulnerabilities in the code.
+  security-auditor:
+    <<: *service-defaults
+    build:
+      <<: *common-build
+      target: builder
+    environment: *common-env
+    command: sh -c "uv run --no-sync bandit -r vexilon/ scripts/ app.py"
+
   # ── Fast Development ───────────────────────────────────────────────────
   # Builds from source with live reload and polling enabled for Podman.
   dev:

--- a/compose.yml
+++ b/compose.yml
@@ -18,6 +18,8 @@ x-common-env: &common-env
 x-common-build: &common-build
   context: .
   dockerfile: Containerfile
+  args:
+    VERSION: ${VEXILON_VERSION:-dev}
 
 # Standard service boilerplate: Resource limits and Persistence
 x-service-defaults: &service-defaults
@@ -55,7 +57,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 30s
+      start_period: 30s # Match the slow model loading period
     depends_on:
       tests:
         condition: service_completed_successfully

--- a/compose.yml
+++ b/compose.yml
@@ -1,55 +1,60 @@
+# ── Reusable Variables ───────────────────────────────────────────────────────
+x-var:
+  - &PORT "7860"
+  - &MEM_LIMIT 3g
+  - &MEM_LIMIT_REFRESH 2g
+
+# Reusable environment for all services
+x-common-env: &common-env
+  ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+  TRANSFORMERS_OFFLINE: "1"
+  HF_HUB_OFFLINE: "1"
+  HF_TOKEN_PATH: /dev/null
+
+# Reusable build configuration
+x-common-build: &common-build
+  context: .
+  dockerfile: Containerfile
+
 services:
 
   # ── Vexilon app ───────────────────────────────────────────────────────────────
+  # Production-ready entry point gated by integration tests.
   vexilon:
-    build:
-      context: .
-      dockerfile: Containerfile
+    build: *common-build
     environment:
-      # Mandatory: Anthropic API key
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
-
-      # Optional: Basic Auth (Login is disabled if VEXILON_PASSWORD is empty)
+      <<: *common-env
       VEXILON_USERNAME: ${VEXILON_USERNAME:-admin}
       VEXILON_PASSWORD: ${VEXILON_PASSWORD:-}
-
-      # Enforce strict offline mode for models baked into the image.
-      HF_TOKEN_PATH: /dev/null
-      TRANSFORMERS_OFFLINE: "1"
-      HF_HUB_OFFLINE: "1"
-
-      PORT: "7860"
+      PORT: *PORT
     ports:
       - "7860:7860"
     cap_drop:
       - ALL
     tmpfs:
-      - /tmp                  # Writable tmp for Gradio and other runtime files
+      - /tmp
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:7860')\""]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
-    mem_limit: 3g
-    memswap_limit: 3g
+    mem_limit: *MEM_LIMIT
+    memswap_limit: *MEM_LIMIT
     depends_on:
       tests:
         condition: service_completed_successfully
     volumes:
       - ./.pdf_cache:/app/.pdf_cache:z
-    # Production-optimized: Uses the CMD defined in the Containerfile
-    # (No 'uv' or 'gradio' CLI required in the final image)
 
   # ── Testing ──────────────────────────────────────────────────────────────────
   # Run with: podman-compose run --rm tests
   tests:
     build:
-      context: .
-      dockerfile: Containerfile
+      <<: *common-build
       target: test_builder
-    mem_limit: 3g         # Integration tests load the real 800 MB embedding model;
-    memswap_limit: 3g     # match mem_limit to disable swap — clean OOM, not host thrash
+    mem_limit: *MEM_LIMIT
+    memswap_limit: *MEM_LIMIT
     volumes:
       - ./.pdf_cache:/app/.pdf_cache:z
       - ./app.py:/app/app.py:ro,z
@@ -61,13 +66,10 @@ services:
       - ./Containerfile:/app/Containerfile:ro,z
       - ./compose.yml:/app/compose.yml:ro,z
     environment:
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      <<: *common-env
       HF_HOME: /app/hf_cache
       EMBED_MODEL: /app/hf_cache
-      TRANSFORMERS_OFFLINE: "1"
-      HF_HUB_OFFLINE: "1"
       PYTHONPATH: "/app"
-    # We use python -m pytest to ensure /app is in the sys.path for module discovery
     command: sh -c "uv run --no-sync python -m pytest tests/test_*.py tests/integration/ -v"
     depends_on:
       index-refresh:
@@ -75,14 +77,12 @@ services:
 
   # ── Cache Refresh ────────────────────────────────────────────────────────────
   # Run with: podman-compose run --rm index-refresh
-  # This updates the local .pdf_cache/ folder using the smart refresh logic.
   index-refresh:
     build:
-      context: .
-      dockerfile: Containerfile
+      <<: *common-build
       target: builder
-    mem_limit: 2g
-    memswap_limit: 2g
+    mem_limit: *MEM_LIMIT_REFRESH
+    memswap_limit: *MEM_LIMIT_REFRESH
     volumes:
       - ./.pdf_cache:/app/.pdf_cache:z
       - ./app.py:/app/app.py:ro,z
@@ -90,9 +90,8 @@ services:
       - ./scripts:/app/scripts:ro,z
       - ./data:/app/data:ro,z
     environment:
+      <<: *common-env
       HF_HOME: /app/hf_cache
-      # Prevent HuggingFace token lookup permission errors
-      HF_TOKEN_PATH: /dev/null
       PATH: "/app/.venv/bin:$PATH"
       PYTHONPATH: "/app"
     command: python scripts/build_index.py
@@ -102,10 +101,9 @@ services:
   app:
     extends: vexilon
     profiles: ["app"]
-    depends_on: [] # This overrides and removes the default dependencies
+    depends_on: []
 
   # ── Fast Development ───────────────────────────────────────────────────
-  # Use: podman compose up --build dev
   # Builds from source with live reload. Loads pre-computed index if available.
   dev:
     extends: vexilon
@@ -113,7 +111,7 @@ services:
       target: builder
     profiles: ["dev"]
     environment:
-      TRANSFORMERS_OFFLINE: "1"
+      <<: *common-env
       HF_HOME: /app/hf_cache
       PATH: "/app/.venv/bin:$PATH"
     volumes:

--- a/compose.yml
+++ b/compose.yml
@@ -16,6 +16,10 @@ x-common-build: &common-build
   context: .
   dockerfile: Containerfile
 
+# Simple source mounting for development/testing
+x-source-volumes: &source-volumes
+  - .:/app:z
+
 services:
 
   # ── Vexilon app ───────────────────────────────────────────────────────────────
@@ -29,10 +33,8 @@ services:
       PORT: *PORT
     ports:
       - "7860:7860"
-    cap_drop:
-      - ALL
-    tmpfs:
-      - /tmp
+    cap_drop: [ALL]
+    tmpfs: [/tmp]
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:7860')\""]
       interval: 30s
@@ -55,16 +57,7 @@ services:
       target: test_builder
     mem_limit: *MEM_LIMIT
     memswap_limit: *MEM_LIMIT
-    volumes:
-      - ./.pdf_cache:/app/.pdf_cache:z
-      - ./app.py:/app/app.py:ro,z
-      - ./tests:/app/tests:ro,z
-      - ./data:/app/data:ro,z
-      - ./vexilon:/app/vexilon:ro,z
-      - ./scripts:/app/scripts:ro,z
-      - ./README.md:/app/README.md:ro,z
-      - ./Containerfile:/app/Containerfile:ro,z
-      - ./compose.yml:/app/compose.yml:ro,z
+    volumes: *source-volumes
     environment:
       <<: *common-env
       HF_HOME: /app/hf_cache
@@ -83,12 +76,7 @@ services:
       target: builder
     mem_limit: *MEM_LIMIT_REFRESH
     memswap_limit: *MEM_LIMIT_REFRESH
-    volumes:
-      - ./.pdf_cache:/app/.pdf_cache:z
-      - ./app.py:/app/app.py:ro,z
-      - ./vexilon:/app/vexilon:ro,z
-      - ./scripts:/app/scripts:ro,z
-      - ./data:/app/data:ro,z
+    volumes: *source-volumes
     environment:
       <<: *common-env
       HF_HOME: /app/hf_cache
@@ -114,13 +102,5 @@ services:
       <<: *common-env
       HF_HOME: /app/hf_cache
       PATH: "/app/.venv/bin:$PATH"
-    volumes:
-      - ./app.py:/app/app.py:ro,z
-      - ./style.css:/app/style.css:ro,z
-      - ./scripts:/app/scripts:ro,z
-      - ./data:/app/data:ro,z
-      - ./vexilon:/app/vexilon:ro,z
-      - ./.pdf_cache:/app/.pdf_cache:z
-      - ./pyproject.toml:/app/pyproject.toml:ro,z
-      - ./uv.lock:/app/uv.lock:ro,z
+    volumes: *source-volumes
     command: sh -c "uv sync --frozen && uv run gradio app.py --watch-dirs ."

--- a/compose.yml
+++ b/compose.yml
@@ -86,27 +86,6 @@ services:
     environment: *common-env
     command: python scripts/build_index.py
 
-  # ── Cache Validator ──────────────────────────────────────────────────────────
-  # Validates that the index is in sync with source files.
-  cache-validator:
-    <<: *service-defaults
-    build:
-      <<: *common-build
-      target: test_builder
-    volumes: *dev-volumes
-    environment: *common-env
-    command: python scripts/generate_cache_manifest.py validate
-
-  # ── Security Auditor ────────────────────────────────────────────────────────
-  # Scans for security vulnerabilities in the code.
-  security-auditor:
-    <<: *service-defaults
-    build:
-      <<: *common-build
-      target: test_builder
-    environment: *common-env
-    command: sh -c "uv run --no-sync bandit -r vexilon/ scripts/ app.py"
-
   # ── Fast Development ───────────────────────────────────────────────────
   # Builds from source with live reload and polling enabled for Podman.
   dev:

--- a/compose.yml
+++ b/compose.yml
@@ -19,19 +19,26 @@ x-common-build: &common-build
   context: .
   dockerfile: Containerfile
 
-# Standard service boilerplate: Resource limits and Volumes
+# Standard service boilerplate: Resource limits and Persistence
 x-service-defaults: &service-defaults
   mem_limit: *MEM_LIMIT
   memswap_limit: *MEM_LIMIT
   volumes:
-    - .:/app:ro,z
     - ./.pdf_cache:/app/.pdf_cache:z
-    - /app/.venv # Prevents host mount from burying the container's installed packages
+
+# Development volumes: Enables live-reload while protecting internal container data
+x-dev-volumes: &dev-volumes
+  - .:/app:ro,z
+  - ./.pdf_cache:/app/.pdf_cache:z
+  - /app/.venv         # Lifeboat for packages
+  - /app/hf_cache      # Lifeboat for the model
+  - /app/.pytest_cache # Lifeboat for test metadata
 
 services:
 
   # ── Vexilon app ───────────────────────────────────────────────────────────────
   # Production-ready entry point gated by integration tests.
+  # Uses code baked into the image for maximum performance/reliability.
   vexilon:
     <<: *service-defaults
     build: *common-build
@@ -44,7 +51,6 @@ services:
     cap_drop: [ALL]
     tmpfs: [/tmp]
     healthcheck:
-      # Use the PORT env var to ensure consistency
       test: ["CMD-SHELL", "python -c \"import os, urllib.request; urllib.request.urlopen('http://localhost:' + os.getenv('PORT', '7860'))\""]
       interval: 30s
       timeout: 10s
@@ -55,12 +61,13 @@ services:
         condition: service_completed_successfully
 
   # ── Testing ──────────────────────────────────────────────────────────────────
-  # Run with: podman-compose run --rm tests
+  # Mounts source code to allow testing local changes without a rebuild.
   tests:
     <<: *service-defaults
     build:
       <<: *common-build
       target: test_builder
+    volumes: *dev-volumes
     environment: *common-env
     command: sh -c "uv run --no-sync python -m pytest tests/test_*.py tests/integration/ -v"
     depends_on:
@@ -68,7 +75,7 @@ services:
         condition: service_completed_successfully
 
   # ── Cache Refresh ────────────────────────────────────────────────────────────
-  # Run with: podman-compose run --rm index-refresh
+  # Runs the indexing script against the baked-in code.
   index-refresh:
     <<: *service-defaults
     build:
@@ -78,14 +85,15 @@ services:
     command: python scripts/build_index.py
 
   # ── Fast Development ───────────────────────────────────────────────────
-  # Builds from source with live reload.
+  # Builds from source with live reload and polling enabled for Podman.
   dev:
     <<: *service-defaults
     extends: vexilon
     build:
       target: builder
     profiles: ["dev"]
+    volumes: *dev-volumes
     environment:
       <<: *common-env
-      WATCHFILES_FORCE_POLLING: "true" # Force polling for reliable reload in Podman
+      WATCHFILES_FORCE_POLLING: "true"
     command: sh -c "uv sync --frozen && uv run gradio app.py --watch-dirs ."

--- a/compose.yml
+++ b/compose.yml
@@ -95,5 +95,6 @@ services:
     environment:
       <<: *common-env
       PATH: "/app/.venv/bin:$PATH"
+      WATCHFILES_FORCE_POLLING: "true" # Force polling for reliable reload in Podman
     volumes: *source-volumes
     command: sh -c "uv sync --frozen && uv run gradio app.py --watch-dirs ."

--- a/compose.yml
+++ b/compose.yml
@@ -9,16 +9,24 @@ x-common-env: &common-env
   ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
   TRANSFORMERS_OFFLINE: "1"
   HF_HUB_OFFLINE: "1"
-  HF_TOKEN_PATH: /dev/null
+  HF_TOKEN_PATH: /dev/null # Prevent HuggingFace token lookup permission errors
 
 # Reusable build configuration
 x-common-build: &common-build
   context: .
   dockerfile: Containerfile
 
-# Simple source mounting for development/testing
+# Explicit source mounting (avoiding .git and system junk)
 x-source-volumes: &source-volumes
-  - .:/app:z
+  - ./app.py:/app/app.py:ro,z
+  - ./style.css:/app/style.css:ro,z
+  - ./tests:/app/tests:ro,z
+  - ./data:/app/data:ro,z
+  - ./vexilon:/app/vexilon:ro,z
+  - ./scripts:/app/scripts:ro,z
+  - ./.pdf_cache:/app/.pdf_cache:z
+  - ./pyproject.toml:/app/pyproject.toml:ro,z
+  - ./uv.lock:/app/uv.lock:ro,z
 
 services:
 
@@ -36,13 +44,14 @@ services:
     cap_drop: [ALL]
     tmpfs: [/tmp]
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:7860')\""]
+      # Use the PORT env var to ensure consistency
+      test: ["CMD-SHELL", "python -c \"import os, urllib.request; urllib.request.urlopen('http://localhost:' + os.getenv('PORT', '7860'))\""]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
     mem_limit: *MEM_LIMIT
-    memswap_limit: *MEM_LIMIT
+    memswap_limit: *MEM_LIMIT # Match mem_limit to disable swap and prevent host thrashing
     depends_on:
       tests:
         condition: service_completed_successfully
@@ -56,7 +65,7 @@ services:
       <<: *common-build
       target: test_builder
     mem_limit: *MEM_LIMIT
-    memswap_limit: *MEM_LIMIT
+    memswap_limit: *MEM_LIMIT # Match mem_limit to disable swap and prevent host thrashing
     volumes: *source-volumes
     environment:
       <<: *common-env
@@ -89,7 +98,7 @@ services:
   app:
     extends: vexilon
     profiles: ["app"]
-    depends_on: []
+    depends_on: [] # Overrides and removes default dependencies from 'vexilon'
 
   # ── Fast Development ───────────────────────────────────────────────────
   # Builds from source with live reload. Loads pre-computed index if available.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dev = [
     "pytest>=8.0.0",                # Test runner
     "pytest-asyncio>=1.3.0",
     "pytest-mock>=3.14.0",          # Mocking fixtures (mocker)
+    "pytest-cov>=6.0.0",            # Coverage reporting
+    "bandit>=1.8.3",                # Security scanning
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,6 @@ dev = [
     "pytest>=8.0.0",                # Test runner
     "pytest-asyncio>=1.3.0",
     "pytest-mock>=3.14.0",          # Mocking fixtures (mocker)
-    "pytest-cov>=6.0.0",            # Coverage reporting
-    "bandit>=1.8.3",                # Security scanning
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -132,6 +132,21 @@ wheels = [
 ]
 
 [[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
+]
+
+[[package]]
 name = "brotli"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -197,6 +212,90 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
 ]
 
 [[package]]
@@ -1152,6 +1251,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
 name = "pytest-mock"
 version = "3.15.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1558,6 +1671,15 @@ wheels = [
 ]
 
 [[package]]
+name = "stevedore"
+version = "5.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
+]
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1803,8 +1925,10 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "bandit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "pytest-mock" },
 ]
 
@@ -1822,7 +1946,9 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "bandit", specifier = ">=1.8.3" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
 ]


### PR DESCRIPTION
## Summary
Refactored the Vexilon `compose.yml` to adopt a modular "LEGO pattern," significantly reducing redundancy while maintaining environmental parity.

### Key Changes
- **Modular Refactor**: Consolidated memory limits, volume mounts, and environment variables into reusable anchors (`x-service-defaults`, `x-common-env`, `x-common-build`).
- **Volume Strategy**: Standardized on an "Overlay" approach: production services use baked-in code, while Dev/Test services use root mounts with "Lifeboat" volumes (`.venv`, `hf_cache`) to prevent dependency masking.
- **Healthcheck Alignment**: Synced `start_period` to **30s** across `compose.yml` and `Containerfile` to ensure reliable model loading.
- **CI Integrity**: Added a dedicated `Compose Validation` job to the PR workflow to catch YAML anchor errors before they hit the test runner.
- **Metadata Support**: Enabled the `VERSION` build argument to ensure containers can identify their build/commit.

### Verification
- Ran `podman compose config` to verify YAML resolution.
- Executed `podman compose up --build tests` with 103/103 passes.
- Verified live-reload functionality in the `dev` profile with polling enabled.

Closes #332