### PR TITLE
fix(ui): constrain chat window height with overflow-y scrolling

### DIFF
--- a/app.py
+++ b/app.py
@@ -106,7 +106,13 @@ _CUSTOM_JS = """
 })()
 """
 
-_CUSTOM_CSS = ""
+_CUSTOM_CSS = """
+#chatbot, #chatbot > .wrapper, #chatbot .message-list {
+    height: calc(100dvh - 21rem) !important;
+    max-height: calc(100dvh - 21rem) !important;
+    overflow-y: auto !important;
+}
+"""
 
 
 


### PR DESCRIPTION
## Summary
- Add `overflow-y: auto` to CSS to prevent chat window from growing indefinitely during streaming responses
- Resolves production issue where chat response window kept expanding

Closes #347