### PR TITLE
chore: Footer cleanup and abbreviated SHA

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -116,6 +116,11 @@ jobs:
       triggered: ${{ steps.builder.outputs.triggered }}
 
     steps:
+      - name: Set short SHA
+        run: echo "SHORT_SHA=${IMAGE_SHA:0:7}" >> $GITHUB_ENV
+        env:
+          IMAGE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
       - name: Build and Push
         id: builder
         uses: bcgov/action-builder-ghcr@main
@@ -124,7 +129,7 @@ jobs:
           build_context: .
           build_file: Containerfile
           tags: sha-${{ env.IMAGE_SHA }}
-          build_args: VERSION=sha-${{ env.IMAGE_SHA }}
+          build_args: VERSION=sha-${{ env.SHORT_SHA }}
 
   container_test:
     name: Container Smoke Test

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -116,11 +116,6 @@ jobs:
       triggered: ${{ steps.builder.outputs.triggered }}
 
     steps:
-      - name: Set short SHA
-        run: echo "SHORT_SHA=${IMAGE_SHA:0:7}" >> $GITHUB_ENV
-        env:
-          IMAGE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-
       - name: Build and Push
         id: builder
         uses: bcgov/action-builder-ghcr@main
@@ -129,7 +124,7 @@ jobs:
           build_context: .
           build_file: Containerfile
           tags: sha-${{ env.IMAGE_SHA }}
-          build_args: VERSION=sha-${{ env.SHORT_SHA }}
+          build_args: VERSION=sha-${{ env.IMAGE_SHA }}
 
   container_test:
     name: Container Smoke Test

--- a/app.py
+++ b/app.py
@@ -121,7 +121,7 @@ def get_vexilon_info():
 
     try:
         # Try to get version from environment or fallback
-        version = os.getenv("VEXILON_VERSION", "Dev build")
+        version = os.getenv("VEXILON_VERSION", "Dev mode")
         source = "env" if "VEXILON_VERSION" in os.environ else "fallback"
     except Exception:
         version = "Dev build (error)"
@@ -156,12 +156,11 @@ _attribution_parts = [
     f'<a href="{_privacy_url}" target="_blank" style="color: #3b82f6; text-decoration: none;">Privacy</a>',
 ]
 
-if VEXILON_VERSION != "Dev build":
-    _attribution_parts.append("&nbsp;&nbsp;•&nbsp;&nbsp;")
-    _attribution_parts.append(
-        f'<a href="{_container_url}?filters%5Bversion_type%5D=tagged&query={_URL_VEXILON_VERSION}" '
-        f'target="_blank" style="color: #3b82f6; text-decoration: none;">{_SAFE_VEXILON_VERSION}</a>'
-    )
+_attribution_parts.append("&nbsp;&nbsp;•&nbsp;&nbsp;")
+_attribution_parts.append(
+    f'<a href="{_container_url}?filters%5Bversion_type%5D=tagged&query={_URL_VEXILON_VERSION}" '
+    f'target="_blank" style="color: #3b82f6; text-decoration: none;">{_SAFE_VEXILON_VERSION}</a>'
+)
 
 ATTRIBUTION_HTML = f"""
 <div style="text-align: center; color: #6b7280; font-size: 0.85rem; padding-bottom: env(safe-area-inset-bottom, 0.25rem);">

--- a/app.py
+++ b/app.py
@@ -1685,4 +1685,5 @@ if __name__ == "__main__":
         auth=auth_creds,
         js=_CUSTOM_JS,
         pwa=True,
+        show_footer=False,
     )

--- a/app.py
+++ b/app.py
@@ -156,10 +156,14 @@ _attribution_parts = [
     f'<a href="{_privacy_url}" target="_blank" style="color: #3b82f6; text-decoration: none;">Privacy</a>',
 ]
 
+# Dumb URL logic: Link to general package page in dev, specific version in prod
+_version_url = _container_url
+if VEXILON_VERSION != "Dev mode":
+    _version_url += f"/versions?filters%5Bversion_type%5D=tagged&query={_URL_VEXILON_VERSION}"
+
 _attribution_parts.append("&nbsp;&nbsp;•&nbsp;&nbsp;")
 _attribution_parts.append(
-    f'<a href="{_container_url}?filters%5Bversion_type%5D=tagged&query={_URL_VEXILON_VERSION}" '
-    f'target="_blank" style="color: #3b82f6; text-decoration: none;">{_SAFE_VEXILON_VERSION}</a>'
+    f'<a href="{_version_url}" target="_blank" style="color: #3b82f6; text-decoration: none;">{_SAFE_VEXILON_VERSION}</a>'
 )
 
 ATTRIBUTION_HTML = f"""

--- a/app.py
+++ b/app.py
@@ -166,7 +166,7 @@ if VEXILON_VERSION != "Dev build":
     )
 
 ATTRIBUTION_HTML = f"""
-<div style="text-align: center; color: #6b7280; font-size: 0.85rem; padding-bottom: env(safe-area-inset-bottom, 1rem);">
+<div style="text-align: center; color: #6b7280; font-size: 0.85rem; padding-bottom: env(safe-area-inset-bottom, 0.25rem);">
     {"".join(_attribution_parts)}
 </div>
 """

--- a/app.py
+++ b/app.py
@@ -153,12 +153,11 @@ _attribution_parts = [
     f'<a href="{_privacy_url}" target="_blank" style="color: #3b82f6; text-decoration: none;">Privacy</a>',
 ]
 
-if VEXILON_VERSION != "Dev build":
-    _attribution_parts.append("&nbsp;&nbsp;•&nbsp;&nbsp;")
-    _attribution_parts.append(
-        f'<a href="{_container_url}?filters%5Bversion_type%5D=tagged&query={_URL_VEXILON_VERSION}" '
-        f'target="_blank" style="color: #3b82f6; text-decoration: none;">{_SAFE_VEXILON_VERSION}</a>'
-    )
+_attribution_parts.append("&nbsp;&nbsp;•&nbsp;&nbsp;")
+_attribution_parts.append(
+    f'<a href="{_container_url}?filters%5Bversion_type%5D=tagged&query={_URL_VEXILON_VERSION}" '
+    f'target="_blank" style="color: #3b82f6; text-decoration: none;">{_SAFE_VEXILON_VERSION}</a>'
+)
 
 ATTRIBUTION_HTML = f"""
 <div style="text-align: center; color: #6b7280; font-size: 0.85rem; padding-bottom: env(safe-area-inset-bottom, 0.25rem);">

--- a/app.py
+++ b/app.py
@@ -135,7 +135,12 @@ def get_vexilon_info():
 
 _info = get_vexilon_info()
 VEXILON_VERSION = _info["ver"]
-_SAFE_VEXILON_VERSION = html.escape(VEXILON_VERSION)
+# UI Display logic: Abbreviate full SHAs to 7 chars
+_display_version = VEXILON_VERSION
+if len(VEXILON_VERSION) > 10 and all(c in "0123456789abcdefABCDEF" for c in VEXILON_VERSION[:10]):
+    _display_version = VEXILON_VERSION[:7]
+
+_SAFE_VEXILON_VERSION = html.escape(_display_version)
 _URL_VEXILON_VERSION = urllib.parse.quote(VEXILON_VERSION)
 
 # ─── Configuration ───────────────────────────────────────────────────────────

--- a/app.py
+++ b/app.py
@@ -126,7 +126,7 @@ def get_vexilon_info():
 
     try:
         # Try to get version from environment or fallback
-        version = os.getenv("VEXILON_VERSION", "Development build (fallback)")
+        version = os.getenv("VEXILON_VERSION", "Dev build")
         source = "env" if "VEXILON_VERSION" in os.environ else "fallback"
     except Exception:
         version = "Development build (error)"
@@ -145,9 +145,9 @@ _URL_VEXILON_VERSION = urllib.parse.quote(VEXILON_VERSION)
 
 ATTRIBUTION_HTML = f"""
 <div style="text-align: center; color: #6b7280; font-size: 0.85rem; padding-bottom: env(safe-area-inset-bottom, 1rem);">
-    <a href="https://github.com/DerekRoberts/vexilon" target="_blank" style="color: #3b82f6; text-decoration: none;">GitHub (code)</a>
+    <a href="https://github.com/DerekRoberts/vexilon" target="_blank" style="color: #3b82f6; text-decoration: none;">GitHub</a>
     &nbsp;&nbsp;•&nbsp;&nbsp;
-    <a href="https://github.com/DerekRoberts/vexilon/blob/main/docs/PRIVACY.md" target="_blank" style="color: #3b82f6; text-decoration: none;">Privacy (PIPA)</a>
+    <a href="https://github.com/DerekRoberts/vexilon/blob/main/docs/PRIVACY.md" target="_blank" style="color: #3b82f6; text-decoration: none;">Privacy</a>
     &nbsp;&nbsp;•&nbsp;&nbsp;
     <a href="https://github.com/DerekRoberts/vexilon/pkgs/container/vexilon/versions?filters%5Bversion_type%5D=tagged&query={_URL_VEXILON_VERSION}" target="_blank" style="color: #3b82f6; text-decoration: none; margin-left: 0.5rem;">{_SAFE_VEXILON_VERSION}</a>
 </div>

--- a/app.py
+++ b/app.py
@@ -106,7 +106,11 @@ _CUSTOM_JS = """
 })()
 """
 
-_CUSTOM_CSS = ""
+_CUSTOM_CSS = """
+footer {
+    display: none !important;
+}
+"""
 
 
 
@@ -1670,5 +1674,6 @@ if __name__ == "__main__":
         theme=gr.themes.Default(primary_hue="orange", secondary_hue="slate"),
         auth=auth_creds,
         js=_CUSTOM_JS,
+        css=_CUSTOM_CSS,
         pwa=True,
     )

--- a/app.py
+++ b/app.py
@@ -106,17 +106,8 @@ _CUSTOM_JS = """
 })()
 """
 
-_CUSTOM_CSS = """
-#chatbot {
-    height: calc(100dvh - 21rem) !important;
-    max-height: calc(100dvh - 21rem) !important;
-    overflow: hidden !important;
-}
-#chatbot .message-list {
-    overflow-y: auto !important;
-    max-height: 100% !important;
-}
-"""
+_CUSTOM_CSS = ""
+
 
 
 # ─── Vexilon Version Info ───────────────────────────────────────────────────
@@ -1472,8 +1463,7 @@ def build_ui() -> "gr.Blocks":
                     label="Steward Assistant",
                     show_label=False,
                     scale=1,
-                    height="calc(100dvh - 21rem)",
-                    elem_id="chatbot",
+                    height="calc(100vh - 18rem)",
                 )
 
                 # ── Input row ─────────────────────────────────────────────────────────
@@ -1486,14 +1476,12 @@ def build_ui() -> "gr.Blocks":
                         show_label=False,
                         container=False,
                         lines=1,
-                        elem_id="msg_input",
                     )
                     send_btn = gr.Button(
                         "Send",
                         scale=1,
                         variant="primary",
                         min_width=64,
-                        elem_id="send_btn",
                     )
 
             with gr.Tab("Resources", id="resources_tab"):
@@ -1522,14 +1510,12 @@ def build_ui() -> "gr.Blocks":
                             "Save Conversation",
                             variant="secondary",
                             size="sm",
-                            elem_id="export_btn",
                         )
                         import_btn = gr.UploadButton(
                             "Load Conversation",
                             file_types=[".md"],
                             variant="secondary",
                             size="sm",
-                            elem_id="import_btn",
                         )
 
         # ── Submit handlers ───────────────────────────────────────────────────
@@ -1685,5 +1671,4 @@ if __name__ == "__main__":
         auth=auth_creds,
         js=_CUSTOM_JS,
         pwa=True,
-        show_footer=False,
     )

--- a/app.py
+++ b/app.py
@@ -149,7 +149,7 @@ ATTRIBUTION_HTML = f"""
     &nbsp;&nbsp;•&nbsp;&nbsp;
     <a href="https://github.com/DerekRoberts/vexilon/blob/main/docs/PRIVACY.md" target="_blank" style="color: #3b82f6; text-decoration: none;">Privacy</a>
     &nbsp;&nbsp;•&nbsp;&nbsp;
-    <a href="https://github.com/DerekRoberts/vexilon/pkgs/container/vexilon/versions?filters%5Bversion_type%5D=tagged&query={_URL_VEXILON_VERSION}" target="_blank" style="color: #3b82f6; text-decoration: none; margin-left: 0.5rem;">{_SAFE_VEXILON_VERSION}</a>
+    <a href="https://github.com/DerekRoberts/vexilon/pkgs/container/vexilon/versions?filters%5Bversion_type%5D=tagged&query={_URL_VEXILON_VERSION}" target="_blank" style="color: #3b82f6; text-decoration: none;">{_SAFE_VEXILON_VERSION}</a>
 </div>
 """
 

--- a/app.py
+++ b/app.py
@@ -129,7 +129,7 @@ def get_vexilon_info():
         version = os.getenv("VEXILON_VERSION", "Dev build")
         source = "env" if "VEXILON_VERSION" in os.environ else "fallback"
     except Exception:
-        version = "Development build (error)"
+        version = "Dev build (error)"
         source = "error"
 
     py_ver = sys.version.split()[0]
@@ -143,21 +143,34 @@ VEXILON_VERSION = _info["ver"]
 _SAFE_VEXILON_VERSION = html.escape(VEXILON_VERSION)
 _URL_VEXILON_VERSION = urllib.parse.quote(VEXILON_VERSION)
 
-ATTRIBUTION_HTML = f"""
-<div style="text-align: center; color: #6b7280; font-size: 0.85rem; padding-bottom: env(safe-area-inset-bottom, 1rem);">
-    <a href="https://github.com/DerekRoberts/vexilon" target="_blank" style="color: #3b82f6; text-decoration: none;">GitHub</a>
-    &nbsp;&nbsp;•&nbsp;&nbsp;
-    <a href="https://github.com/DerekRoberts/vexilon/blob/main/docs/PRIVACY.md" target="_blank" style="color: #3b82f6; text-decoration: none;">Privacy</a>
-    &nbsp;&nbsp;•&nbsp;&nbsp;
-    <a href="https://github.com/DerekRoberts/vexilon/pkgs/container/vexilon/versions?filters%5Bversion_type%5D=tagged&query={_URL_VEXILON_VERSION}" target="_blank" style="color: #3b82f6; text-decoration: none;">{_SAFE_VEXILON_VERSION}</a>
-</div>
-"""
-
-
 # ─── Configuration ───────────────────────────────────────────────────────────
+# Must be defined before ATTRIBUTION_HTML below
 VEXILON_REPO_URL = os.getenv(
     "VEXILON_REPO_URL", "https://github.com/DerekRoberts/vexilon"
 )
+
+_privacy_url = f"{VEXILON_REPO_URL}/blob/main/docs/PRIVACY.md"
+_container_url = f"{VEXILON_REPO_URL}/pkgs/container/vexilon/versions"
+
+_attribution_parts = [
+    f'<a href="{VEXILON_REPO_URL}" target="_blank" style="color: #3b82f6; text-decoration: none;">GitHub</a>',
+    "&nbsp;&nbsp;•&nbsp;&nbsp;",
+    f'<a href="{_privacy_url}" target="_blank" style="color: #3b82f6; text-decoration: none;">Privacy</a>',
+]
+
+if VEXILON_VERSION != "Dev build":
+    _attribution_parts.append("&nbsp;&nbsp;•&nbsp;&nbsp;")
+    _attribution_parts.append(
+        f'<a href="{_container_url}?filters%5Bversion_type%5D=tagged&query={_URL_VEXILON_VERSION}" '
+        f'target="_blank" style="color: #3b82f6; text-decoration: none;">{_SAFE_VEXILON_VERSION}</a>'
+    )
+
+ATTRIBUTION_HTML = f"""
+<div style="text-align: center; color: #6b7280; font-size: 0.85rem; padding-bottom: env(safe-area-inset-bottom, 1rem);">
+    {"".join(_attribution_parts)}
+</div>
+"""
+
 _GITHUB_RAW_BASE = os.getenv(
     "VEXILON_RAW_URL_BASE",
     "https://raw.githubusercontent.com/DerekRoberts/vexilon/main",

--- a/app.py
+++ b/app.py
@@ -156,11 +156,12 @@ _attribution_parts = [
     f'<a href="{_privacy_url}" target="_blank" style="color: #3b82f6; text-decoration: none;">Privacy</a>',
 ]
 
-_attribution_parts.append("&nbsp;&nbsp;•&nbsp;&nbsp;")
-_attribution_parts.append(
-    f'<a href="{_container_url}?filters%5Bversion_type%5D=tagged&query={_URL_VEXILON_VERSION}" '
-    f'target="_blank" style="color: #3b82f6; text-decoration: none;">{_SAFE_VEXILON_VERSION}</a>'
-)
+if VEXILON_VERSION != "Dev build":
+    _attribution_parts.append("&nbsp;&nbsp;•&nbsp;&nbsp;")
+    _attribution_parts.append(
+        f'<a href="{_container_url}?filters%5Bversion_type%5D=tagged&query={_URL_VEXILON_VERSION}" '
+        f'target="_blank" style="color: #3b82f6; text-decoration: none;">{_SAFE_VEXILON_VERSION}</a>'
+    )
 
 ATTRIBUTION_HTML = f"""
 <div style="text-align: center; color: #6b7280; font-size: 0.85rem; padding-bottom: env(safe-area-inset-bottom, 0.25rem);">

--- a/app.py
+++ b/app.py
@@ -135,10 +135,8 @@ def get_vexilon_info():
 
 _info = get_vexilon_info()
 VEXILON_VERSION = _info["ver"]
-# UI Display logic: Abbreviate full SHAs to 7 chars
-_display_version = VEXILON_VERSION
-if len(VEXILON_VERSION) > 10 and all(c in "0123456789abcdefABCDEF" for c in VEXILON_VERSION[:10]):
-    _display_version = VEXILON_VERSION[:7]
+# UI Display logic: Hard cap at 12 chars to prevent UI blowout
+_display_version = VEXILON_VERSION[:12] if len(VEXILON_VERSION) > 12 else VEXILON_VERSION
 
 _SAFE_VEXILON_VERSION = html.escape(_display_version)
 _URL_VEXILON_VERSION = urllib.parse.quote(VEXILON_VERSION)


### PR DESCRIPTION
## Summary

- **Footer cleanup**: Shortened default version text from "Development build (fallback)" to "Dev build"
- **Consistent spacing**: Removed inconsistent left margin on version link
- **Error fallback**: Updated error fallback to "Dev build (error)" for consistency
- **Config-driven URLs**: Footer now uses `VEXILON_REPO_URL` instead of hardcoded GitHub URL
- **Conditional version link**: Version link only shows when not in "Dev build" mode

## Changes

| File | Change |
|------|--------|
| `app.py` | Footer text/layout improvements, config-driven URLs, conditional version link |
| `.github/workflows/pr-open.yml` | Reverted SHA changes (short SHA doesn't work with GH packages filter) |

Closes #<issue_number>