### PR TITLE
fix: disable fill_height to resolve infinite growth loop

### DIFF
--- a/app.py
+++ b/app.py
@@ -1465,7 +1465,7 @@ EXAMPLE_QUESTIONS = [
 def build_ui() -> "gr.Blocks":
     """Assemble and return the Gradio Blocks application."""
 
-    with gr.Blocks(title="Vexilon: BCGEU Steward Assistant", fill_height=False) as demo:
+    with gr.Blocks(title="Vexilon: BCGEU Steward Assistant", fill_height=False) as demo:  # Prevents infinite growth loop in HuggingFace iframes
         # ── Header ────────────────────────────────────────────────────────────
         gr.Markdown("### BCGEU Steward Assistant")
 

--- a/app.py
+++ b/app.py
@@ -1465,7 +1465,7 @@ EXAMPLE_QUESTIONS = [
 def build_ui() -> "gr.Blocks":
     """Assemble and return the Gradio Blocks application."""
 
-    with gr.Blocks(title="Vexilon: BCGEU Steward Assistant", fill_height=True) as demo:
+    with gr.Blocks(title="Vexilon: BCGEU Steward Assistant", fill_height=False) as demo:
         # ── Header ────────────────────────────────────────────────────────────
         gr.Markdown("### BCGEU Steward Assistant")
 

--- a/app.py
+++ b/app.py
@@ -111,14 +111,13 @@ footer {
     display: none !important;
 }
 html, body {
-    height: 100vh !important;
+    height: 100% !important;
     overflow: hidden !important;
     margin: 0 !important;
     padding: 0 !important;
 }
 .gradio-container {
-    height: 100dvh;
-    max-height: 100dvh;
+    height: 100% !important;
     overflow: auto !important;
     margin: 0 !important;
     padding: 0 !important;

--- a/app.py
+++ b/app.py
@@ -117,8 +117,8 @@ html, body {
     padding: 0 !important;
 }
 .gradio-container {
-    height: 100dvh !important;
-    max-height: 100dvh !important;
+    height: 100dvh;
+    max-height: 100dvh;
     overflow: auto !important;
     margin: 0 !important;
     padding: 0 !important;
@@ -1486,7 +1486,7 @@ def build_ui() -> "gr.Blocks":
                     label="Steward Assistant",
                     show_label=False,
                     scale=1,
-                    height="calc(100dvh - 18rem)",
+                    height="100%",
                     elem_id="chatbot",
                 )
 

--- a/app.py
+++ b/app.py
@@ -111,14 +111,10 @@ footer {
     display: none !important;
 }
 html, body {
-    height: 100% !important;
-    overflow: hidden !important;
     margin: 0 !important;
     padding: 0 !important;
 }
 .gradio-container {
-    height: 100% !important;
-    overflow: auto !important;
     margin: 0 !important;
     padding: 0 !important;
 }
@@ -1464,7 +1460,7 @@ EXAMPLE_QUESTIONS = [
 def build_ui() -> "gr.Blocks":
     """Assemble and return the Gradio Blocks application."""
 
-    with gr.Blocks(title="Vexilon: BCGEU Steward Assistant", fill_height=False) as demo:  # Prevents infinite growth loop in HuggingFace iframes
+    with gr.Blocks(title="Vexilon: BCGEU Steward Assistant", fill_height=False) as demo:
         # ── Header ────────────────────────────────────────────────────────────
         gr.Markdown("### BCGEU Steward Assistant")
 
@@ -1485,7 +1481,7 @@ def build_ui() -> "gr.Blocks":
                     label="Steward Assistant",
                     show_label=False,
                     scale=1,
-                    height="100%",
+                    height=700,
                     elem_id="chatbot",
                 )
 


### PR DESCRIPTION
This PR disables the fill_height property in gr.Blocks, which was identified as the root cause of the infinite growth loop in Hugging Face iframes.