### PR TITLE
feat(ui): shorten VEXILON_VERSION SHA in footer

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,6 +47,9 @@ _index: "faiss.IndexFlatIP | None" = None
 INTEGRITY_WARNING: str | None = None
 
 VEXILON_VERSION = os.getenv("VEXILON_VERSION", "Dev mode")
+if len(VEXILON_VERSION) > 12:
+    VEXILON_VERSION = VEXILON_VERSION[:7]
+
 VEXILON_REPO_URL = os.getenv("VEXILON_REPO_URL", "https://github.com/DerekRoberts/vexilon")
 GITHUB_LABOUR_LAW_URL = os.getenv(
     "VEXILON_KNOWLEDGE_URL", f"{VEXILON_REPO_URL}/tree/main/data/labour_law"


### PR DESCRIPTION
Caps the VEXILON_VERSION display to 7 characters if it's a long string (like a Git SHA). This keeps the footer UI clean and prevents overflow issues in spaces.