### PR TITLE
fix(ui): restore backend connection and stabilize UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,6 +47,9 @@ _index: "faiss.IndexFlatIP | None" = None
 INTEGRITY_WARNING: str | None = None
 
 VEXILON_VERSION = os.getenv("VEXILON_VERSION", "Dev mode")
+if len(VEXILON_VERSION) > 12:
+    VEXILON_VERSION = VEXILON_VERSION[:7]
+
 VEXILON_REPO_URL = os.getenv("VEXILON_REPO_URL", "https://github.com/DerekRoberts/vexilon")
 GITHUB_LABOUR_LAW_URL = os.getenv(
     "VEXILON_KNOWLEDGE_URL", f"{VEXILON_REPO_URL}/tree/main/data/labour_law"

--- a/app.py
+++ b/app.py
@@ -323,7 +323,7 @@ with gr.Blocks(title="BCGEU Navigator", fill_height=True) as demo:
             interactive=True
         )
     
-    chatbot = gr.Chatbot(show_label=False, scale=1, fill_height=True, min_height=400, buttons=[])
+    chatbot = gr.Chatbot(show_label=False, scale=1, height="70vh", min_height=400, buttons=[])
     
     with gr.Row():
         msg = gr.Textbox(show_label=False, placeholder="Type a message...", container=False, scale=7)

--- a/app.py
+++ b/app.py
@@ -53,7 +53,7 @@ GITHUB_LABOUR_LAW_URL = os.getenv(
 )
 
 # Models
-DEFAULT_MODEL_LLM = os.getenv("VEXILON_DEFAULT_MODEL", "claude-haiku-4-5-20251001")
+DEFAULT_MODEL_LLM = os.getenv("VEXILON_DEFAULT_MODEL", "claude-haiku-4-7-20260416")
 CLAUDE_MODEL = os.getenv("VEXILON_CLAUDE_MODEL", DEFAULT_MODEL_LLM)
 REVIEWER_MODEL = os.getenv("VEXILON_REVIEWER_MODEL", DEFAULT_MODEL_LLM)
 CONDENSE_MODEL = os.getenv("VEXILON_CONDENSE_MODEL", DEFAULT_MODEL_LLM)
@@ -272,11 +272,15 @@ async def chat_fn(message, history, persona):
     
     # 2. Stream assistant response
     accumulated = ""
-    async for chunk in rag_review_stream(message, history, persona):
-        accumulated += chunk
-        # Update history with current accumulated response
-        current_history = new_history + [{"role": "assistant", "content": accumulated}]
-        yield "", current_history, gr.update(open=False)
+    try:
+        async for chunk in rag_review_stream(message, history, persona):
+            accumulated += chunk
+            current_history = new_history + [{"role": "assistant", "content": accumulated}]
+            yield "", current_history, gr.update(open=False)
+    except Exception as e:
+        logger.error(f"[ui] Chat failed: {e}", exc_info=True)
+        error_history = new_history + [{"role": "assistant", "content": f"❌ Error: {str(e)}"}]
+        yield "", error_history, gr.update(open=True)
 
 # ─── UI Layout ──────────────────────────────────────────────────────────────
 EXAMPLES = [
@@ -323,7 +327,7 @@ with gr.Blocks(title="BCGEU Navigator", fill_height=True) as demo:
             interactive=True
         )
     
-    chatbot = gr.Chatbot(show_label=False, scale=1, height="70vh", min_height=400)
+    chatbot = gr.Chatbot(show_label=False, scale=1, height=650, min_height=400)
     
     with gr.Row():
         msg = gr.Textbox(show_label=False, placeholder="Type a message...", container=False, scale=7)

--- a/app.py
+++ b/app.py
@@ -47,9 +47,6 @@ _index: "faiss.IndexFlatIP | None" = None
 INTEGRITY_WARNING: str | None = None
 
 VEXILON_VERSION = os.getenv("VEXILON_VERSION", "Dev mode")
-if len(VEXILON_VERSION) > 12:
-    VEXILON_VERSION = VEXILON_VERSION[:7]
-
 VEXILON_REPO_URL = os.getenv("VEXILON_REPO_URL", "https://github.com/DerekRoberts/vexilon")
 GITHUB_LABOUR_LAW_URL = os.getenv(
     "VEXILON_KNOWLEDGE_URL", f"{VEXILON_REPO_URL}/tree/main/data/labour_law"
@@ -386,7 +383,7 @@ with gr.Blocks(title="BCGEU Navigator", fill_height=True) as demo:
             &nbsp;&nbsp;•&nbsp;&nbsp;
             <a href="{VEXILON_REPO_URL}/blob/main/docs/PRIVACY.md" target="_blank" style="color: #3b82f6; text-decoration: none;">Privacy</a>
             &nbsp;&nbsp;•&nbsp;&nbsp;
-            <a href="{VEXILON_REPO_URL}" target="_blank" style="color: #3b82f6; text-decoration: none;">{VEXILON_VERSION}</a>
+            <a href="{VEXILON_REPO_URL}" target="_blank" style="color: #3b82f6; text-decoration: none;">{VEXILON_VERSION[:7] if len(VEXILON_VERSION) > 12 else VEXILON_VERSION}</a>
         </div>
     """)
 

--- a/app.py
+++ b/app.py
@@ -323,7 +323,7 @@ with gr.Blocks(title="BCGEU Navigator", fill_height=True) as demo:
             interactive=True
         )
     
-    chatbot = gr.Chatbot(show_label=False, scale=1, min_height=400, buttons=[])
+    chatbot = gr.Chatbot(show_label=False, scale=1, fill_height=True, min_height=400, buttons=[])
     
     with gr.Row():
         msg = gr.Textbox(show_label=False, placeholder="Type a message...", container=False, scale=7)

--- a/app.py
+++ b/app.py
@@ -312,8 +312,7 @@ footer { display: none !important; }
 }
 """
 
-if __name__ == "__main__":
-    startup()
+startup()
 
 with gr.Blocks(title="BCGEU Navigator", fill_height=True) as demo:
     with gr.Row():

--- a/app.py
+++ b/app.py
@@ -323,7 +323,7 @@ with gr.Blocks(title="BCGEU Navigator", fill_height=True) as demo:
             interactive=True
         )
     
-    chatbot = gr.Chatbot(show_label=False, scale=1, height="70vh", min_height=400, buttons=[])
+    chatbot = gr.Chatbot(show_label=False, scale=1, height="70vh", min_height=400)
     
     with gr.Row():
         msg = gr.Textbox(show_label=False, placeholder="Type a message...", container=False, scale=7)

--- a/app.py
+++ b/app.py
@@ -383,7 +383,7 @@ with gr.Blocks(title="BCGEU Navigator", fill_height=True) as demo:
             &nbsp;&nbsp;•&nbsp;&nbsp;
             <a href="{VEXILON_REPO_URL}/blob/main/docs/PRIVACY.md" target="_blank" style="color: #3b82f6; text-decoration: none;">Privacy</a>
             &nbsp;&nbsp;•&nbsp;&nbsp;
-            <a href="{VEXILON_REPO_URL}" target="_blank" style="color: #3b82f6; text-decoration: none;">{VEXILON_VERSION[:7] if len(VEXILON_VERSION) > 12 else VEXILON_VERSION}</a>
+            <a href="{VEXILON_REPO_URL}" target="_blank" style="color: #3b82f6; text-decoration: none;">{VEXILON_VERSION[:11]}</a>
         </div>
     """)
 


### PR DESCRIPTION
Consolidated emergency fix for the 'fucked' backend and UI: 1. Upgrades model to claude-haiku-4-7-20260416. 2. Adds try-except error handling to chat_fn. 3. Sets height to 650 to break the iframe-resizer loop. 4. Keeps version SHA truncation at 11 chars.