### PR TITLE
feat(ui): fix chat input regression post-overhaul

### DIFF
--- a/app.py
+++ b/app.py
@@ -287,14 +287,6 @@ EXAMPLES = [
     "Does my employer have a social media policy?"
 ]
 
-CLOSE_ACCORDION_JS = """
-() => {
-    const btn = document.querySelector('#quick-questions-accordion .label-wrap');
-    if (btn && btn.classList.contains('open')) {
-        btn.click();
-    }
-}
-"""
 
 _CSS = """
 footer { display: none !important; }
@@ -337,8 +329,7 @@ with gr.Blocks(title="BCGEU Navigator", fill_height=True) as demo:
                 example_btn.click(
                     chat_fn, 
                     [gr.State(q), chatbot, persona], 
-                    [msg, chatbot, toolbox],
-                    js=CLOSE_ACCORDION_JS.replace("quick-questions-accordion", "steward-toolbox")
+                    [msg, chatbot, toolbox]
                 )
 
         gr.Markdown("---")
@@ -387,8 +378,8 @@ with gr.Blocks(title="BCGEU Navigator", fill_height=True) as demo:
         </div>
     """)
 
-    msg.submit(chat_fn, [msg, chatbot, persona], [msg, chatbot, toolbox], js=CLOSE_ACCORDION_JS.replace("quick-questions-accordion", "steward-toolbox"))
-    submit.click(chat_fn, [msg, chatbot, persona], [msg, chatbot, toolbox], js=CLOSE_ACCORDION_JS.replace("quick-questions-accordion", "steward-toolbox"))
+    msg.submit(chat_fn, [msg, chatbot, persona], [msg, chatbot, toolbox])
+    submit.click(chat_fn, [msg, chatbot, persona], [msg, chatbot, toolbox])
 
 if __name__ == "__main__":
     port = int(os.getenv("PORT", 7860))

--- a/app.py
+++ b/app.py
@@ -262,21 +262,29 @@ def startup(force_rebuild: bool = False):
             INTEGRITY_WARNING = f"⚠️ Index Incomplete: {len(report['failed_files'])} documents failed."
 
 async def chat_fn(message, history, persona):
-    if not message:
-        yield "", history, gr.update()
-        return
-    
-    # 1. Update history with user message
-    new_history = history + [{"role": "user", "content": message}]
-    yield "", new_history, gr.update(open=False)
-    
-    # 2. Stream assistant response
-    accumulated = ""
-    async for chunk in rag_review_stream(message, history, persona):
-        accumulated += chunk
-        # Update history with current accumulated response
-        current_history = new_history + [{"role": "assistant", "content": accumulated}]
-        yield "", current_history, gr.update(open=False)
+    try:
+        if not message:
+            yield "", history, gr.update()
+            return
+        
+        # 1. Update history with user message
+        new_history = history + [{"role": "user", "content": message}]
+        yield "", new_history, gr.update(open=False)
+        
+        # 2. Stream assistant response
+        accumulated = ""
+        async for chunk in rag_review_stream(message, history, persona):
+            accumulated += chunk
+            # Update history with current accumulated response
+            current_history = new_history + [{"role": "assistant", "content": accumulated}]
+            yield "", current_history, gr.update(open=False)
+            
+    except Exception as e:
+        logger.error(f"[ui] chat_fn failed: {e}", exc_info=True)
+        # Yield the error to the UI so the user isn't left hanging
+        error_msg = f"❌ **Error:** {str(e)}"
+        error_history = (history or []) + [{"role": "user", "content": message or ""}, {"role": "assistant", "content": error_msg}]
+        yield "", error_history, gr.update()
 
 # ─── UI Layout ──────────────────────────────────────────────────────────────
 EXAMPLES = [
@@ -315,7 +323,12 @@ with gr.Blocks(title="BCGEU Navigator", fill_height=True) as demo:
             interactive=True
         )
     
-    chatbot = gr.Chatbot(show_label=False, scale=1, height="70vh", min_height=400)
+    chatbot = gr.Chatbot(
+        show_label=False, 
+        scale=1, 
+        height="70vh", 
+        min_height=400
+    )
     
     with gr.Row():
         msg = gr.Textbox(show_label=False, placeholder="Type a message...", container=False, scale=7)


### PR DESCRIPTION
This PR fixes the regression where the main chat input box failed to trigger a response.

### Root Cause
The recent UI overhaul added a `js` parameter to the `msg.submit` and `submit.click` handlers to close the toolbox accordion. However, because the JS function did not explicitly return the arguments it received, Gradio 6 was overriding the first input (`message`) with `undefined` (converting to `None` in Python), causing the `chat_fn` to exit early.

### Fix
- Removed the redundant and buggy JS accordion logic from all event handlers.
- The UI already handles accordion closure natively via `gr.update(open=False)` in the Python `chat_fn` generator, which is more robust and doesn't interfere with input mapping.
- Verified fix locally on port 7865 with both manual text entry and Toolbox examples.

Closes #392