### PR TITLE
feat(ui): remove recurring share/delete/copy buttons

### DIFF
--- a/app.py
+++ b/app.py
@@ -323,7 +323,7 @@ footer { display: none !important; }
     margin-bottom: 0.5rem;
 }
 /* Aggressive button suppression for Gradio 6.x UI stability */
-.message-buttons, .share-button, .undo-button, .retry-button, .copy-button {
+.message-buttons, .share-button, .undo-button, .retry-button, .copy-button, .clear-button, button[aria-label="Clear"] {
     display: none !important;
 }
 """

--- a/app.py
+++ b/app.py
@@ -322,6 +322,10 @@ footer { display: none !important; }
 #resources-accordion .prose li {
     margin-bottom: 0.5rem;
 }
+/* Aggressive button suppression for Gradio 6.x UI stability */
+.message-buttons, .share-button, .undo-button, .retry-button, .copy-button {
+    display: none !important;
+}
 """
 
 if __name__ == "__main__":
@@ -339,7 +343,16 @@ with gr.Blocks(title="BCGEU Navigator", fill_height=True) as demo:
             interactive=True
         )
     
-    chatbot = gr.Chatbot(show_label=False, scale=1, height="70vh", min_height=400)
+    chatbot = gr.Chatbot(
+        show_label=False, 
+        scale=1, 
+        height="70vh", 
+        min_height=400,
+        show_copy_button=False,
+        show_share_button=False,
+        show_undo_button=False,
+        show_retry_button=False
+    )
     
     with gr.Row():
         msg = gr.Textbox(show_label=False, placeholder="Type a message...", container=False, scale=7)

--- a/app.py
+++ b/app.py
@@ -315,11 +315,11 @@ CLOSE_ACCORDION_JS = """
 _CSS = """
 footer { display: none !important; }
 /* Hanging indent for the Resources & Utilities list items */
-#resources-accordion .prose ul {
+#steward-toolbox .prose ul {
     list-style-position: outside;
     padding-left: 1.5rem;
 }
-#resources-accordion .prose li {
+#steward-toolbox .prose li {
     margin-bottom: 0.5rem;
 }
 /* Aggressive button suppression for Gradio 6.x UI stability */

--- a/app.py
+++ b/app.py
@@ -343,16 +343,7 @@ with gr.Blocks(title="BCGEU Navigator", fill_height=True) as demo:
             interactive=True
         )
     
-    chatbot = gr.Chatbot(
-        show_label=False, 
-        scale=1, 
-        height="70vh", 
-        min_height=400,
-        show_copy_button=False,
-        show_share_button=False,
-        show_undo_button=False,
-        show_retry_button=False
-    )
+    chatbot = gr.Chatbot(show_label=False, scale=1, height="70vh", min_height=400, buttons=[])
     
     with gr.Row():
         msg = gr.Textbox(show_label=False, placeholder="Type a message...", container=False, scale=7)


### PR DESCRIPTION
This PR aggressively disables the message-level action buttons (copy, share, undo, retry) in Gradio 6.x through both component-level flags and CSS overrides. Closes #buttons-gate