### PR TITLE
chore: require explicit space name in deployment

### DIFF
--- a/.agents/workflows/cicd-spec.md
+++ b/.agents/workflows/cicd-spec.md
@@ -56,6 +56,6 @@ The `COPY --from=builder /app/hf_cache /app/hf_cache` line in the Containerfile 
 | `.github/workflows/pr-open.yml` | Tests + builds Docker image on PR |
 | `.github/workflows/deploy-test.yml` | Deploys to test HF Space on push to main |
 | `.github/workflows/deploy-prod.yml` | Deploys to prod HF Space on release |
-| `.github/scripts/deploy.sh` | Pushes stub Dockerfile + README to HF Space. Usage: `<space_name> <image_ref> [--dry-run]` |
+| `.github/scripts/deploy.sh` | Pushes stub Dockerfile + README to HF Space. Usage: `<space_name> [image_ref] [--dry-run]` |
 | `Containerfile` | Multi-stage Docker build |
 | `tests/test_deploy_integrity.py` | Automated checks for the constraints above |

--- a/.agents/workflows/cicd-spec.md
+++ b/.agents/workflows/cicd-spec.md
@@ -56,6 +56,6 @@ The `COPY --from=builder /app/hf_cache /app/hf_cache` line in the Containerfile 
 | `.github/workflows/pr-open.yml` | Tests + builds Docker image on PR |
 | `.github/workflows/deploy-test.yml` | Deploys to test HF Space on push to main |
 | `.github/workflows/deploy-prod.yml` | Deploys to prod HF Space on release |
-| `.github/scripts/deploy.sh` | Pushes stub Dockerfile + README to HF Space |
+| `.github/scripts/deploy.sh` | Pushes stub Dockerfile + README to HF Space. Usage: `<space_name> <image_ref> [--dry-run]` |
 | `Containerfile` | Multi-stage Docker build |
 | `tests/test_deploy_integrity.py` | Automated checks for the constraints above |

--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -1,32 +1,23 @@
-# Usage: ./.github/scripts/deploy.sh <image_ref> [--prod] [--dry-run]
-# <image_ref> can be a tag (e.g. 'sha-abc123') or a digest (e.g. 'sha256:abc123...')
-# Default: Targets "DerekRoberts/landru" (TEST).
-# Use --prod as second argument to target "DerekRoberts/vexilon".
-
+#!/bin/bash
 # Strict mode + Trace
 set -euo pipefail
 
 # Usage function
 usage() {
-    echo "Usage: $0 <image_ref> [--prod] [--dry-run]"
+    echo "Usage: $0 <space_name> <image_ref> [--dry-run]"
+    echo "  <space_name>: Full name of the Hugging Face Space (e.g. 'DerekRoberts/vexilon')"
     echo "  <image_ref>: Tag or digest of the image to deploy"
-    echo "  --prod: Target 'DerekRoberts/vexilon' (default is TEST 'DerekRoberts/landru')"
     echo "  --dry-run: Show what would be done without performing it"
     exit 1
 }
 
+SPACE_NAME=""
 IMAGE_REF=""
-SPACE_NAME="DerekRoberts/landru"
 DRY_RUN=false
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --prod)
-            echo "[safety] Production mode enabled."
-            SPACE_NAME="DerekRoberts/vexilon"
-            shift
-            ;;
         --dry-run)
             DRY_RUN=true
             shift
@@ -36,10 +27,12 @@ while [[ $# -gt 0 ]]; do
             usage
             ;;
         *)
-            if [ -z "$IMAGE_REF" ]; then
+            if [ -z "$SPACE_NAME" ]; then
+                SPACE_NAME="$1"
+            elif [ -z "$IMAGE_REF" ]; then
                 IMAGE_REF="$1"
             else
-                echo "Error: Multiple image references provided: $IMAGE_REF and $1"
+                echo "Error: Extra argument provided: $1"
                 usage
             fi
             shift
@@ -47,8 +40,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [ -z "$IMAGE_REF" ]; then
-    echo "Error: Image reference (e.g. 'sha-abc123' or 'sha256:abc123...') must be provided."
+if [ -z "$SPACE_NAME" ] || [ -z "$IMAGE_REF" ]; then
+    echo "Error: Both space_name and image_ref must be provided."
     usage
 fi
 
@@ -105,13 +98,15 @@ if [ -n "${GITHUB_ACTIONS:-}" ]; then
 fi
 
 # Re-add only the essentials (including app.py as requested)
-# We also need to fix the README.md metadata on-the-fly to use sdk: docker
-sed -i 's/^sdk: gradio/sdk: docker/' README.md
+# Ensure SDK is set to docker in README.md
+sed -i 's/^sdk: .*/sdk: docker/' README.md
 git add Dockerfile README.md app.py
 git commit -m "promote: $IMAGE_REF from $ORIGINAL_REF"
 
 # Auth and Push
-git remote add hf "https://huggingface.co/spaces/${SPACE_NAME}" 2>/dev/null || true
+# Remove existing remote to avoid collision/stale URLs
+git remote remove hf 2>/dev/null || true
+git remote add hf "https://huggingface.co/spaces/${SPACE_NAME}"
 git config --local credential.https://huggingface.co.helper '!f() { echo "username=api"; echo "password=${HF_TOKEN}"; }; f'
 git push hf hf-snapshot:main --force --no-verify
 

--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Usage: ./.github/scripts/deploy.sh <space_name> <image_ref> [--dry-run]
+# <space_name>: Full name of the Hugging Face Space (e.g. 'DerekRoberts/vexilon')
+# <image_ref>: Tag or digest of the image to deploy (falls back to short SHA if omitted)
+#
 # Strict mode + Trace
 set -euo pipefail
 
@@ -104,8 +108,8 @@ if [ -n "${GITHUB_ACTIONS:-}" ]; then
 fi
 
 # Re-add only the essentials (including app.py as requested)
-# Ensure SDK is set to docker in README.md
-sed -i 's/^sdk: .*/sdk: docker/' README.md
+# Ensure SDK is set to docker in README.md (portable sed)
+sed 's/^sdk: .*/sdk: docker/' README.md > README.md.tmp && mv README.md.tmp README.md
 git add Dockerfile README.md app.py
 git commit -m "promote: $IMAGE_REF from $ORIGINAL_REF"
 

--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
-# Usage: ./.github/scripts/deploy.sh <space_name> <image_ref> [--dry-run]
+# Usage: ./.github/scripts/deploy.sh <space_name> [image_ref] [--dry-run]
 # <space_name>: Full name of the Hugging Face Space (e.g. 'DerekRoberts/vexilon')
-# <image_ref>: Tag or digest of the image to deploy (falls back to short SHA if omitted)
+# [image_ref]: Tag or digest of the image to deploy (falls back to short SHA if omitted)
 #
 # Strict mode + Trace
 set -euo pipefail
 
 # Usage function
 usage() {
-    echo "Usage: $0 <space_name> <image_ref> [--dry-run]"
+    echo "Usage: $0 <space_name> [image_ref] [--dry-run]"
     echo "  <space_name>: Full name of the Hugging Face Space (e.g. 'DerekRoberts/vexilon')"
-    echo "  <image_ref>: Tag or digest of the image to deploy"
+    echo "  [image_ref]: Tag or digest of the image to deploy"
     echo "  --dry-run: Show what would be done without performing it"
     exit 1
 }

--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -40,9 +40,15 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [ -z "$SPACE_NAME" ] || [ -z "$IMAGE_REF" ]; then
-    echo "Error: Both space_name and image_ref must be provided."
+if [ -z "$SPACE_NAME" ]; then
+    echo "Error: space_name (e.g. 'DerekRoberts/landru') must be provided."
     usage
+fi
+
+# Fallback to current short SHA if no image ref provided
+if [ -z "$IMAGE_REF" ]; then
+    IMAGE_REF=$(git rev-parse --short HEAD)
+    echo "[info] No image reference provided. Falling back to current SHA: $IMAGE_REF"
 fi
 
 if [ -z "${HF_TOKEN:-}" ] && [ "$DRY_RUN" == "false" ]; then

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -49,7 +49,7 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           TAG=$(echo '${{ steps.resolve.outputs.bundle }}' | jq -r '.vexilon')
-          ./.github/scripts/deploy.sh "$TAG" --prod
+          ./.github/scripts/deploy.sh "DerekRoberts/vexilon" "$TAG"
 
       - name: Verify Space boots successfully
         env:

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -42,7 +42,7 @@ jobs:
           if [ -z "$TAG" ]; then
             TAG=$(echo "$BUNDLE" | jq -r '.vexilon')
           fi
-          ./.github/scripts/deploy.sh "$TAG"
+          ./.github/scripts/deploy.sh "DerekRoberts/landru" "$TAG"
 
       - name: Verify Space boots successfully
         env:


### PR DESCRIPTION
Strips out default SPACE_NAME and --prod flag. Deploy script now requires positional arguments: <space_name> <image_ref>.