### PR TITLE
feat(ui): stabilize footer metadata and deep-link version

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -124,7 +124,9 @@ jobs:
           build_context: .
           build_file: Containerfile
           tags: sha-${{ env.IMAGE_SHA }}
-          build_args: VERSION=sha-${{ env.IMAGE_SHA }}
+          build_args: |
+            VERSION=sha-${{ env.IMAGE_SHA }}
+            REPO_URL=https://github.com/${{ github.repository }}
 
   container_test:
     name: Container Smoke Test

--- a/Containerfile
+++ b/Containerfile
@@ -90,7 +90,9 @@ RUN --mount=type=cache,target=/app/.pdf_cache_mount,uid=1001,gid=1001 \
 
 # ── Final Environment ────────────────────────────────────────────────────────
 ARG VERSION
+ARG REPO_URL
 ENV VEXILON_VERSION=$VERSION
+ENV VEXILON_REPO_URL=$REPO_URL
 
 EXPOSE 7860
 

--- a/Containerfile
+++ b/Containerfile
@@ -89,8 +89,8 @@ RUN --mount=type=cache,target=/app/.pdf_cache_mount,uid=1001,gid=1001 \
     cp -r /app/.pdf_cache/* /app/.pdf_cache_mount/ 2>/dev/null || true
 
 # ── Final Environment ────────────────────────────────────────────────────────
-ARG VERSION
-ARG REPO_URL
+ARG VERSION="Dev mode"
+ARG REPO_URL="https://github.com/DerekRoberts/vexilon"
 ENV VEXILON_VERSION=$VERSION
 ENV VEXILON_REPO_URL=$REPO_URL
 

--- a/app.py
+++ b/app.py
@@ -634,13 +634,14 @@ with gr.Blocks(title="BCGEU Navigator", fill_height=True) as demo:
 
     import_btn.upload(fn=handle_import, inputs=[import_btn], outputs=[chatbot])
 
+    _URL_VEXILON_VERSION = urllib.parse.quote(VEXILON_VERSION)
     gr.HTML(f"""
         <div style="text-align: center; color: #6b7280; font-size: 0.85rem; padding: 10px 0;">
             <a href="{VEXILON_REPO_URL}" target="_blank" style="color: #3b82f6; text-decoration: none;">GitHub</a>
             &nbsp;&nbsp;•&nbsp;&nbsp;
             <a href="{VEXILON_REPO_URL}/blob/main/docs/PRIVACY.md" target="_blank" style="color: #3b82f6; text-decoration: none;">Privacy</a>
             &nbsp;&nbsp;•&nbsp;&nbsp;
-            <a href="{VEXILON_REPO_URL}" target="_blank" style="color: #3b82f6; text-decoration: none;">{VEXILON_VERSION[:11]}</a>
+            <a href="{VEXILON_REPO_URL}/pkgs/container/vexilon/versions?filters%5Bversion_type%5D=tagged&query={_URL_VEXILON_VERSION}" target="_blank" style="color: #3b82f6; text-decoration: none;">{VEXILON_VERSION[:11]}</a>
         </div>
     """)
 


### PR DESCRIPTION
Separates the footer deep-linking and build-time metadata injection into a dedicated PR for better isolation.