### PR TITLE
fix(ui): correct GitHub package search parameter

### DIFF
--- a/app.py
+++ b/app.py
@@ -637,11 +637,11 @@ with gr.Blocks(title="BCGEU Navigator", fill_height=True) as demo:
     _URL_VEXILON_VERSION = urllib.parse.quote(VEXILON_VERSION)
     gr.HTML(f"""
         <div style="text-align: center; color: #6b7280; font-size: 0.85rem; padding: 10px 0;">
-            <a href="{VEXILON_REPO_URL}" target="_blank" style="color: #3b82f6; text-decoration: none;">GitHub</a>
+            <a href="{VEXILON_REPO_URL}" target="_blank" rel="noopener noreferrer" style="color: #3b82f6; text-decoration: none;">GitHub</a>
             &nbsp;&nbsp;•&nbsp;&nbsp;
-            <a href="{VEXILON_REPO_URL}/blob/main/docs/PRIVACY.md" target="_blank" style="color: #3b82f6; text-decoration: none;">Privacy</a>
+            <a href="{VEXILON_REPO_URL}/blob/main/docs/PRIVACY.md" target="_blank" rel="noopener noreferrer" style="color: #3b82f6; text-decoration: none;">Privacy</a>
             &nbsp;&nbsp;•&nbsp;&nbsp;
-            <a href="{VEXILON_REPO_URL}/pkgs/container/vexilon/versions?filters%5Bversion_type%5D=tagged&q={_URL_VEXILON_VERSION}" target="_blank" style="color: #3b82f6; text-decoration: none;">{VEXILON_VERSION[:11]}</a>
+            <a href="{VEXILON_REPO_URL}/pkgs/container/vexilon/versions?filters%5Bversion_type%5D=tagged&q={_URL_VEXILON_VERSION}" target="_blank" rel="noopener noreferrer" style="color: #3b82f6; text-decoration: none;">{VEXILON_VERSION[:11]}</a>
         </div>
     """)
 

--- a/app.py
+++ b/app.py
@@ -634,19 +634,13 @@ with gr.Blocks(title="BCGEU Navigator", fill_height=True) as demo:
 
     import_btn.upload(fn=handle_import, inputs=[import_btn], outputs=[chatbot])
 
-    if VEXILON_VERSION == "Dev mode":
-        _VEXILON_PKG_URL = f"{VEXILON_REPO_URL}/pkgs/container/vexilon"
-    else:
-        _URL_VEXILON_VERSION = urllib.parse.quote(VEXILON_VERSION)
-        _VEXILON_PKG_URL = f"{VEXILON_REPO_URL}/pkgs/container/vexilon/versions?filters%5Bversion_type%5D=tagged&q={_URL_VEXILON_VERSION}"
-
     gr.HTML(f"""
         <div style="text-align: center; color: #6b7280; font-size: 0.85rem; padding: 10px 0;">
             <a href="{VEXILON_REPO_URL}" target="_blank" rel="noopener noreferrer" style="color: #3b82f6; text-decoration: none;">GitHub</a>
             &nbsp;&nbsp;•&nbsp;&nbsp;
             <a href="{VEXILON_REPO_URL}/blob/main/docs/PRIVACY.md" target="_blank" rel="noopener noreferrer" style="color: #3b82f6; text-decoration: none;">Privacy</a>
             &nbsp;&nbsp;•&nbsp;&nbsp;
-            <a href="{_VEXILON_PKG_URL}" target="_blank" rel="noopener noreferrer" style="color: #3b82f6; text-decoration: none;">{VEXILON_VERSION[:11]}</a>
+            <a href="{VEXILON_REPO_URL}/pkgs/container/vexilon" target="_blank" rel="noopener noreferrer" style="color: #3b82f6; text-decoration: none;">{VEXILON_VERSION[:11]}</a>
         </div>
     """)
 

--- a/app.py
+++ b/app.py
@@ -641,7 +641,7 @@ with gr.Blocks(title="BCGEU Navigator", fill_height=True) as demo:
             &nbsp;&nbsp;•&nbsp;&nbsp;
             <a href="{VEXILON_REPO_URL}/blob/main/docs/PRIVACY.md" target="_blank" style="color: #3b82f6; text-decoration: none;">Privacy</a>
             &nbsp;&nbsp;•&nbsp;&nbsp;
-            <a href="{VEXILON_REPO_URL}/pkgs/container/vexilon/versions?filters%5Bversion_type%5D=tagged&query={_URL_VEXILON_VERSION}" target="_blank" style="color: #3b82f6; text-decoration: none;">{VEXILON_VERSION[:11]}</a>
+            <a href="{VEXILON_REPO_URL}/pkgs/container/vexilon/versions?filters%5Bversion_type%5D=tagged&q={_URL_VEXILON_VERSION}" target="_blank" style="color: #3b82f6; text-decoration: none;">{VEXILON_VERSION[:11]}</a>
         </div>
     """)
 

--- a/app.py
+++ b/app.py
@@ -634,14 +634,19 @@ with gr.Blocks(title="BCGEU Navigator", fill_height=True) as demo:
 
     import_btn.upload(fn=handle_import, inputs=[import_btn], outputs=[chatbot])
 
-    _URL_VEXILON_VERSION = urllib.parse.quote(VEXILON_VERSION)
+    if VEXILON_VERSION == "Dev mode":
+        _VEXILON_PKG_URL = f"{VEXILON_REPO_URL}/pkgs/container/vexilon"
+    else:
+        _URL_VEXILON_VERSION = urllib.parse.quote(VEXILON_VERSION)
+        _VEXILON_PKG_URL = f"{VEXILON_REPO_URL}/pkgs/container/vexilon/versions?filters%5Bversion_type%5D=tagged&q={_URL_VEXILON_VERSION}"
+
     gr.HTML(f"""
         <div style="text-align: center; color: #6b7280; font-size: 0.85rem; padding: 10px 0;">
             <a href="{VEXILON_REPO_URL}" target="_blank" rel="noopener noreferrer" style="color: #3b82f6; text-decoration: none;">GitHub</a>
             &nbsp;&nbsp;•&nbsp;&nbsp;
             <a href="{VEXILON_REPO_URL}/blob/main/docs/PRIVACY.md" target="_blank" rel="noopener noreferrer" style="color: #3b82f6; text-decoration: none;">Privacy</a>
             &nbsp;&nbsp;•&nbsp;&nbsp;
-            <a href="{VEXILON_REPO_URL}/pkgs/container/vexilon/versions?filters%5Bversion_type%5D=tagged&q={_URL_VEXILON_VERSION}" target="_blank" rel="noopener noreferrer" style="color: #3b82f6; text-decoration: none;">{VEXILON_VERSION[:11]}</a>
+            <a href="{_VEXILON_PKG_URL}" target="_blank" rel="noopener noreferrer" style="color: #3b82f6; text-decoration: none;">{VEXILON_VERSION[:11]}</a>
         </div>
     """)
 


### PR DESCRIPTION
Updates the footer link to use 'q' instead of 'query' for filtering container versions on GitHub.