### PR TITLE
docs: add contributor onboarding guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# How to contribute
+
+Government employees, public and members of the private sector are encouraged to contribute to the repository by **creating a branch and submitting a pull request**. Outside forks come with permissions complications, but can still be accepted.
+
+(If you are new to GitHub, you might start with a [basic tutorial](https://help.github.com/articles/set-up-git) and check out a more detailed guide to [pull requests](https://help.github.com/articles/using-pull-requests/).)
+
+Pull requests will be evaluated by the repository guardians on a schedule and if deemed beneficial will be committed to the main branch.
+
+All contributors retain the original copyright to their stuff, but by contributing to this project, you grant a world-wide, royalty-free, perpetual, irrevocable, non-exclusive, transferable license to all users **under the terms of the [license](./LICENSE.md) under which this project is distributed**.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,4 +6,4 @@ You are encouraged to contribute to the repository by **creating a branch and su
 
 Pull requests will be evaluated by the repository guardians are intended to be squash merged to the main branch.
 
-All contributors retain the original copyright to their works, but by contributing to this project, you grant a world-wide, royalty-free, perpetual, irrevocable, non-exclusive, transferable license to all users **under the terms of the [license](./LICENSE.md) under which this project is distributed**.
+All contributors retain the original copyright to their works, but by contributing to this project, you grant a world-wide, royalty-free, perpetual, irrevocable, non-exclusive, transferable license to all users **under the terms of the [license](./LICENSE) under which this project is distributed**.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # How to contribute
 
-Government employees, public and members of the private sector are encouraged to contribute to the repository by **creating a branch and submitting a pull request**. Outside forks come with permissions complications, but can still be accepted.
+You are encouraged to contribute to the repository by **creating a branch and submitting a pull request**. Outside forks come with permissions complications, but can still be accepted.
 
 (If you are new to GitHub, you might start with a [basic tutorial](https://help.github.com/articles/set-up-git) and check out a more detailed guide to [pull requests](https://help.github.com/articles/using-pull-requests/).)
 
-Pull requests will be evaluated by the repository guardians on a schedule and if deemed beneficial will be committed to the main branch.
+Pull requests will be evaluated by the repository guardians are intended to be squash merged to the main branch.
 
-All contributors retain the original copyright to their stuff, but by contributing to this project, you grant a world-wide, royalty-free, perpetual, irrevocable, non-exclusive, transferable license to all users **under the terms of the [license](./LICENSE.md) under which this project is distributed**.
+All contributors retain the original copyright to their works, but by contributing to this project, you grant a world-wide, royalty-free, perpetual, irrevocable, non-exclusive, transferable license to all users **under the terms of the [license](./LICENSE.md) under which this project is distributed**.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ export ANTHROPIC_API_KEY=<YOUR_ANTHROPIC_API_KEY>
 python scripts/pdf_to_md.py path/to/document.pdf
 ```
 
+## 🚀 Contributing
+
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute to this project.
+
 ## Configuration
 
 All settings are optional — defaults match the product specification.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,11 @@ python scripts/pdf_to_md.py path/to/document.pdf
 
 ## 🚀 Contributing
 
-Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute to this project.
+We welcome contributions from everyone! Whether you are interested in development, infrastructure, or documentation, your help is appreciated.
+
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for our full guidelines. To get started:
+- Browse the [Issue Tracker](https://github.com/DerekRoberts/vexilon/issues).
+- Look for the **`good first issue`** label—these are specifically curated tasks for those new to the project.
 
 ## Configuration
 


### PR DESCRIPTION
Added a new section to README.md to help onboard new contributors, specifically focusing on how to find issues using labels.