### PR TITLE
fix(ci): fetch-depth for deployments

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 20
 
       - name: Resolve image
         id: resolve

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 20
 
       - name: Resolve image
         id: resolve


### PR DESCRIPTION
Fixes missing `fetch-depth: 20` in deploy workflows checkout steps as required by the CI/CD specification.