### PR TITLE
fix(ci): restore fast test_builder to unblock unit tests

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           load: true
           files: compose.yml
-          targets: dev
+          targets: test-unit
           set: |
             *.cache-from=type=gha
             *.cache-to=type=gha,mode=max

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -62,6 +62,7 @@ jobs:
           targets: dev,staging
           set: |
             *.cache-from=type=gha
+            *.cache-from=type=registry,ref=ghcr.io/miniontech/vexilon/agnav:buildcache
             *.cache-to=type=gha,mode=max
 
   test-unit:
@@ -87,6 +88,7 @@ jobs:
           targets: test-unit
           set: |
             *.cache-from=type=gha
+            *.cache-from=type=registry,ref=ghcr.io/miniontech/vexilon/agnav:buildcache
             *.cache-to=type=gha,mode=max
 
       - name: Run Containerized Unit Tests
@@ -127,6 +129,7 @@ jobs:
           targets: dev
           set: |
             *.cache-from=type=gha
+            *.cache-from=type=registry,ref=ghcr.io/miniontech/vexilon/agnav:buildcache
             *.cache-to=type=gha,mode=max
 
       - name: Validate Cache Manifest
@@ -160,6 +163,7 @@ jobs:
           targets: dev
           set: |
             *.cache-from=type=gha
+            *.cache-from=type=registry,ref=ghcr.io/miniontech/vexilon/agnav:buildcache
             *.cache-to=type=gha,mode=max
 
       - name: Run Integration Tests
@@ -195,6 +199,7 @@ jobs:
           targets: dev
           set: |
             *.cache-from=type=gha
+            *.cache-from=type=registry,ref=ghcr.io/miniontech/vexilon/agnav:buildcache
             *.cache-to=type=gha,mode=max
 
       - name: Run Integration Tests (App)
@@ -236,6 +241,7 @@ jobs:
           targets: dev,staging
           set: |
             *.cache-from=type=gha
+            *.cache-from=type=registry,ref=ghcr.io/miniontech/vexilon/agnav:buildcache
             *.cache-to=type=gha,mode=max
 
       - name: Run E2E Tests

--- a/app/Containerfile
+++ b/app/Containerfile
@@ -52,11 +52,25 @@ COPY pyproject.toml uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     HF_HUB_OFFLINE=1 UV_LINK_MODE=copy uv sync --frozen --no-dev --no-install-project
 
+# Final Source Code
+COPY main.py ./
+COPY . ./
+
+# ─── Stage 2.1: Test Builder (Unit Tests - Lightweight) ──────────────────────
+FROM builder AS test_builder
+# Layer dev dependencies on top of the production venv
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen
+
+# Prepare directories for testing and ensure permissions
+RUN mkdir -p /app/reports /app/.pytest_cache /hf_cache && \
+    chown -R 1000:1000 /app/reports /app/.pytest_cache /hf_cache
+
+# ─── Stage 2.2: Indexed Builder (Production Indexing) ────────────────────────
+FROM builder AS indexed_builder
+
 # Model and FAISS Index (Cached unless data/ or scripts change)
 COPY --from=model_fetcher /model /model
-COPY data/ ./data/
-COPY indexing.py ./
-COPY scripts/build_index.py ./scripts/
 
 RUN --mount=type=cache,target=/app/.pdf_cache_mount \
     mkdir -p /app/.pdf_cache && \
@@ -64,12 +78,10 @@ RUN --mount=type=cache,target=/app/.pdf_cache_mount \
     TRANSFORMERS_OFFLINE=1 HF_HUB_OFFLINE=1 PATH="/app/.venv/bin:$PATH" python scripts/build_index.py && \
     cp -r /app/.pdf_cache/* /app/.pdf_cache_mount/ 2>/dev/null || true
 
-# Final Source Code
-COPY main.py ./
-COPY . ./
-
 # ─── Stage 2.5: Functional Builder (Dev/Test Source) ──────────────────────────
-FROM builder AS functional_builder
+FROM indexed_builder AS functional_builder
+
+
 # Layer dev dependencies on top of the production venv
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen
@@ -85,7 +97,7 @@ FROM base AS runner
 ENV PATH="/app/.venv/bin:$PATH"
 
 # Copy everything from the builder (including the pre-computed index)
-COPY --from=builder /app /app
+COPY --from=indexed_builder /app /app
 COPY --from=model_fetcher /model /model
 
 # Ensure the app user owns the directories it needs to write to (reports/cache)

--- a/app/Containerfile
+++ b/app/Containerfile
@@ -55,10 +55,11 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # ─── Stage 2.1: Test Builder (Unit Tests - Lightweight) ──────────────────────
 FROM builder AS test_builder
 COPY --from=model_fetcher /model /model
-COPY . ./
 # Layer dev dependencies on top of the production venv
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen
+    uv sync --frozen --no-install-project
+
+COPY . ./
 
 # Prepare directories for testing and ensure permissions
 RUN mkdir -p /app/reports /app/.pytest_cache /hf_cache && \
@@ -79,16 +80,18 @@ RUN --mount=type=cache,target=/app/.pdf_cache_mount \
     TRANSFORMERS_OFFLINE=1 HF_HUB_OFFLINE=1 PATH="/app/.venv/bin:$PATH" python scripts/build_index.py && \
     cp -r /app/.pdf_cache/* /app/.pdf_cache_mount/ 2>/dev/null || true
 
-# Copy remaining source code for the runner and functional tests
-COPY . ./
+# (Source code will be copied in leaf stages to maximize cache hits)
 
 # ─── Stage 2.5: Functional Builder (Dev/Test Source) ──────────────────────────
 FROM indexed_builder AS functional_builder
 
 
-# Layer dev dependencies on top of the production venv
+# Layer dev dependencies on top of the production venv (Cached unless uv.lock changes)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen
+    uv sync --frozen --no-install-project
+
+# Now copy the remaining source code (Fast, frequently changed)
+COPY . ./
 
 # Prepare directories for testing and ensure permissions
 RUN mkdir -p /app/reports /app/.pytest_cache /hf_cache && \
@@ -103,6 +106,9 @@ ENV PATH="/app/.venv/bin:$PATH"
 # Copy everything from the builder (including the pre-computed index)
 COPY --from=indexed_builder /app /app
 COPY --from=model_fetcher /model /model
+
+# Copy the actual application source code
+COPY . ./
 
 # Ensure the app user owns the directories it needs to write to (reports/cache)
 RUN mkdir -p /app/.pdf_cache /app/reports /hf_cache /model && \

--- a/app/Containerfile
+++ b/app/Containerfile
@@ -104,15 +104,16 @@ FROM base AS runner
 ENV PATH="/app/.venv/bin:$PATH"
 
 # Copy everything from the builder (including the pre-computed index)
-COPY --from=indexed_builder /app /app
-COPY --from=model_fetcher /model /model
+COPY --from=indexed_builder --chown=1000:1000 /app /app
+COPY --from=model_fetcher --chown=1000:1000 /model /model
 
 # Copy the actual application source code
-COPY . ./
+COPY --chown=1000:1000 main.py ./
+COPY --chown=1000:1000 prompts/ ./prompts/
 
-# Ensure the app user owns the directories it needs to write to (reports/cache)
-RUN mkdir -p /app/.pdf_cache /app/reports /hf_cache /model && \
-    chown -R 1000:1000 /app/.pdf_cache /app/reports /hf_cache /model
+# Ensure the app user owns the directories it needs to write to
+RUN mkdir -p /hf_cache && \
+    chown -R 1000:1000 /hf_cache
 
 USER 1000
 

--- a/app/Containerfile
+++ b/app/Containerfile
@@ -52,12 +52,9 @@ COPY pyproject.toml uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     HF_HUB_OFFLINE=1 UV_LINK_MODE=copy uv sync --frozen --no-dev --no-install-project
 
-# Final Source Code
-COPY main.py ./
-COPY . ./
-
 # ─── Stage 2.1: Test Builder (Unit Tests - Lightweight) ──────────────────────
 FROM builder AS test_builder
+COPY . ./
 # Layer dev dependencies on top of the production venv
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen
@@ -71,12 +68,18 @@ FROM builder AS indexed_builder
 
 # Model and FAISS Index (Cached unless data/ or scripts change)
 COPY --from=model_fetcher /model /model
+COPY data/ ./data/
+COPY indexing.py ./
+COPY scripts/build_index.py ./scripts/
 
 RUN --mount=type=cache,target=/app/.pdf_cache_mount \
     mkdir -p /app/.pdf_cache && \
     cp -r /app/.pdf_cache_mount/* /app/.pdf_cache/ 2>/dev/null || true && \
     TRANSFORMERS_OFFLINE=1 HF_HUB_OFFLINE=1 PATH="/app/.venv/bin:$PATH" python scripts/build_index.py && \
     cp -r /app/.pdf_cache/* /app/.pdf_cache_mount/ 2>/dev/null || true
+
+# Copy remaining source code for the runner and functional tests
+COPY . ./
 
 # ─── Stage 2.5: Functional Builder (Dev/Test Source) ──────────────────────────
 FROM indexed_builder AS functional_builder

--- a/app/Containerfile
+++ b/app/Containerfile
@@ -104,16 +104,16 @@ FROM base AS runner
 ENV PATH="/app/.venv/bin:$PATH"
 
 # Copy everything from the builder (including the pre-computed index)
-COPY --from=indexed_builder --chown=1000:1000 /app /app
-COPY --from=model_fetcher --chown=1000:1000 /model /model
+COPY --from=indexed_builder /app /app
+COPY --from=model_fetcher /model /model
 
 # Copy the actual application source code
-COPY --chown=1000:1000 main.py ./
-COPY --chown=1000:1000 prompts/ ./prompts/
+COPY main.py ./
+COPY prompts/ ./prompts/
 
-# Ensure the app user owns the directories it needs to write to
-RUN mkdir -p /hf_cache && \
-    chown -R 1000:1000 /hf_cache
+# Only create and chown (by UID) the specific directories that MUST be writable
+RUN mkdir -p /app/.pdf_cache /app/reports /hf_cache && \
+    chown -R 1000:1000 /app/.pdf_cache /app/reports /hf_cache
 
 USER 1000
 

--- a/app/Containerfile
+++ b/app/Containerfile
@@ -54,6 +54,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # ─── Stage 2.1: Test Builder (Unit Tests - Lightweight) ──────────────────────
 FROM builder AS test_builder
+COPY --from=model_fetcher /model /model
 COPY . ./
 # Layer dev dependencies on top of the production venv
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/compose.yml
+++ b/compose.yml
@@ -158,10 +158,9 @@ services:
     container_name: vexilon-test-unit
     <<: *service-defaults
     image: vexilon:dev
-    build: *build-dev
-    depends_on:
-      test-cache:
-        condition: service_completed_successfully
+    build:
+      <<: *common-build
+      target: test_builder
     environment: *test-env
     # Shared healthcheck not needed for one-off test runners
     command: >

--- a/compose.yml
+++ b/compose.yml
@@ -157,7 +157,7 @@ services:
   test-unit:
     container_name: vexilon-test-unit
     <<: *service-defaults
-    image: vexilon:dev
+    image: vexilon:test-unit
     build:
       <<: *common-build
       target: test_builder


### PR DESCRIPTION
Restores the `test_builder` target in `Containerfile` to allow unit tests to bypass the 5+ minute FAISS index build step. 

Previously, `test-unit` was pointing to the `dev` target which implicitly required building the full FAISS index, causing both `Prepare Test Cache` and `Unit Tests` to take over 8 minutes.

By decoupling the index step into an `indexed_builder` stage and using `test_builder` for logic tests, the cache warning can occur in parallel while unit tests finish in ~2 minutes.