### PR TITLE
Python 3.14 Guardian Protocol

### DIFF
--- a/.agents/workflows/agent-discipline.md
+++ b/.agents/workflows/agent-discipline.md
@@ -36,3 +36,18 @@ To prevent accidental regression and "downgrades" that frustrate the team, the f
 - **LLM Models**: **Qwen 3** is the primary target. Do not use Qwen 2.5, 2.9, or any non-Qwen 3 model in production configurations.
 - **Exemptions**: Lightweight models for CI/testing (e.g., `tinyllama` in `compose.yml`) are EXEMPT from the model regression rule, but the core application logic must target Qwen 3.
 - **Verification**: Any change affecting `compose.yml`, `Containerfile`, or `pyproject.toml` MUST be double-checked against these constraints.
+
+## 7. Verification Protocol
+- **Incremental Verification (The "Dev" Check)**: 
+  - For iterative work, use `podman compose up --build dev` (or equivalent) to verify logs and manual output.
+  - **The Log Receipt**: If you claim a feature is running, you must show the relevant log lines from the container output.
+- **Final Verification (The "Pre-Flight" Check)**:
+  - Before declaring a task "Done" or opening a PR, the agent MUST attempt to run specific test services (e.g., `test-unit` or `test-cache`) if they are relevant to the change.
+- **Environment Awareness**: 
+  - Always prefer `podman` over `docker` if available in the environment, following the project's established patterns.
+- **No Psychic Claims**: Never assume code works because it "looks correct." You are not a compiler. If there is no terminal output, the verification didn't happen.
+
+## 8. Dependency Discipline
+- **Forward-Only Rule**: NEVER pin an old version or downgrade a package to "fix" a Python 3.14 compatibility issue. 
+- **Upgrade First**: We are on the bleeding edge; our dependencies MUST be too. ALWAYS attempt to upgrade to the latest stable version of a package first before exploring hacks or pinning.
+- **Verification**: After any dependency change, run `uv sync` and verify that the environment is stable on Python 3.14.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Guardian Hook: Prevents Python 3.14 downgrades
+
+CONTAINERFILE="app/Containerfile"
+PYPROJECT="app/pyproject.toml"
+
+# Check Containerfile
+if grep -q "FROM python:" "$CONTAINERFILE" && ! grep -q "FROM python:3.14" "$CONTAINERFILE"; then
+    echo "ERROR: Attempted to downgrade Python in $CONTAINERFILE."
+    echo "Python 3.14 is MANDATORY for the anyio.NoEventLoopError fix."
+    exit 1
+fi
+
+# Check pyproject.toml
+if grep -q "requires-python =" "$PYPROJECT" && ! grep -q 'requires-python = ">=3.14"' "$PYPROJECT"; then
+    echo "ERROR: Attempted to downgrade Python in $PYPROJECT."
+    echo "Python 3.14 is MANDATORY for the anyio.NoEventLoopError fix."
+    exit 1
+fi
+
+exit 0

--- a/app/Containerfile
+++ b/app/Containerfile
@@ -1,4 +1,5 @@
 # ─── Stage 0: Base ────────────────────────────────────────────────────────────
+# CRITICAL: DO NOT DOWNGRADE. Python 3.14 is required for anyio.NoEventLoopError fix in Starlette 1.0.0.
 FROM python:3.14-slim AS base
 
 # Silence Hugging Face nag messages globally

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -2,7 +2,8 @@
 name = "agnav"
 version = "0.1.0"
 description = "BCGEU Collective Agreement RAG Chatbot"
-requires-python = ">=3.12"
+# CRITICAL: Python 3.14+ required for anyio.NoEventLoopError fix in Starlette 1.0.0
+requires-python = ">=3.14"
 dependencies = [
     # ── Web UI ──────────────────────────────────────────────────────────────
     "gradio==6.14.0",

--- a/openspec/AGENTS.md
+++ b/openspec/AGENTS.md
@@ -9,5 +9,7 @@ You MUST adhere to the following rules at all times:
     - NEVER downgrade Python 3.14 to 3.12 or lower.
     - NEVER downgrade Qwen 3 to Qwen 2.5 or lower.
 3. **Verification**: After any change to `compose.yml` or `Containerfile`, verify that the versions haven't been reverted.
-4. **Communication**: If you encounter a situation where a downgrade seems necessary, STOP and ask the human. Do not make the decision yourself.
+4. **The Receipt Rule**: Every claim of success MUST be backed by terminal output. For incremental work, use `podman compose up --build dev` and show the logs. For final work, run the relevant `test-*` services.
+5. **Forward-Only Dependencies**: NEVER pin an old version or downgrade a package to "fix" a Python 3.14 compatibility issue. ALWAYS attempt to upgrade to the latest stable version first.
+6. **Communication**: If you encounter a situation where a downgrade seems necessary, STOP and ask the human. Do not make the decision yourself.
 </openspec-instructions>


### PR DESCRIPTION
This PR adds explicit 'CRITICAL' comments to config files and a git pre-commit hook to prevent agents from downgrading Python. Closes #guardian-protocol