### PR TITLE
feat(rag): implement document tiering and score boosting for retrieval

### DIFF
--- a/app/indexing.py
+++ b/app/indexing.py
@@ -5,6 +5,7 @@ import hashlib
 import fitz
 import logging
 from pathlib import Path
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
 logger = logging.getLogger(__name__)
@@ -36,6 +37,9 @@ CHUNK_SIZE = int(os.getenv("CHUNK_SIZE", 512))
 CHUNK_OVERLAP = int(os.getenv("CHUNK_OVERLAP", 100))
 EMBED_DIM = int(os.getenv("EMBED_DIM", "384"))
 SIMILARITY_TOP_K = int(os.getenv("SIMILARITY_TOP_K", 40))
+# Document score boosting weights
+TIER1_BOOST = float(os.getenv("AGNAV_TIER1_BOOST", "1.2"))
+TIER3_BOOST = float(os.getenv("AGNAV_TIER3_BOOST", "0.8"))
 
 
 _embed_model: Any = None
@@ -271,6 +275,7 @@ def embed_texts(texts: list[str]) -> "np.ndarray":
     embeddings = model.encode(texts, show_progress_bar=False, convert_to_numpy=True)
     return embeddings.astype(np.float32)
 
+@lru_cache(maxsize=128)
 def get_document_tier_weight(source_name: str, path: str = "") -> float:
     """
     Determine the retrieval boost weight for a document based on its tier.
@@ -278,9 +283,6 @@ def get_document_tier_weight(source_name: str, path: str = "") -> float:
     - Tier 3: Statutory and general secondary resources (default 0.8)
     - Tier 2: Core agreements, jurisprudence, forms, etc. (default 1.0)
     """
-    tier1_boost = float(os.getenv("AGNAV_TIER1_BOOST", "1.2"))
-    tier3_boost = float(os.getenv("AGNAV_TIER3_BOOST", "0.8"))
-
     # Normalise input paths and source names for robust matching
     path_lower = path.lower().replace("\\", "/")
     source_lower = source_name.lower()
@@ -298,7 +300,7 @@ def get_document_tier_weight(source_name: str, path: str = "") -> float:
     )
 
     if is_standards_of_conduct or is_19th_agreement:
-        return tier1_boost
+        return TIER1_BOOST
 
     # Tier 3 checks:
     # 1. Statutory regulations: '02_statutory/' folder or source names
@@ -315,7 +317,7 @@ def get_document_tier_weight(source_name: str, path: str = "") -> float:
     )
 
     if is_statutory or is_general_resource:
-        return tier3_boost
+        return TIER3_BOOST
 
     # Tier 2: Default
     return 1.0

--- a/app/indexing.py
+++ b/app/indexing.py
@@ -121,7 +121,7 @@ def _is_toc_or_index_page(page_text: str) -> bool:
         return True
     return False
 
-def chunk_text(full_text: str, token_data: list[tuple[int, int, int, str]], source_name: str) -> list[dict]:
+def chunk_text(full_text: str, token_data: list[tuple[int, int, int, str]], source_name: str, path: str = "") -> list[dict]:
     chunks = []
     if not token_data:
         return chunks
@@ -140,6 +140,7 @@ def chunk_text(full_text: str, token_data: list[tuple[int, int, int, str]], sour
             "source": source_name,
             "header": header,
             "chunk_index": idx,
+            "path": path,
         })
         idx += 1
         start += step
@@ -206,7 +207,11 @@ def load_md_chunks(md_path: Path) -> list[dict]:
             
         char_offset += len(line) + 1
 
-    return chunk_text(filtered_content, token_metadata, source_name)
+    try:
+        rel_path = str(md_path.relative_to(DATA_DIR))
+    except ValueError:
+        rel_path = md_path.name
+    return chunk_text(filtered_content, token_metadata, source_name, path=rel_path)
 
 def load_pdf_chunks(pdf_path: Path, strict: bool = False) -> list[dict]:
     source_name = _get_source_name(pdf_path.stem)
@@ -247,7 +252,11 @@ def load_pdf_chunks(pdf_path: Path, strict: bool = False) -> list[dict]:
 
             char_offset += len(page_text) + 1
             
-        return chunk_text(full_text, token_metadata, source_name)
+        try:
+            rel_path = str(pdf_path.relative_to(DATA_DIR))
+        except ValueError:
+            rel_path = pdf_path.name
+        return chunk_text(full_text, token_metadata, source_name, path=rel_path)
     except Exception as e:
         if strict:
             raise FileIntegrityError(f"Critical error parsing {pdf_path}: {e}")
@@ -262,21 +271,68 @@ def embed_texts(texts: list[str]) -> "np.ndarray":
     embeddings = model.encode(texts, show_progress_bar=False, convert_to_numpy=True)
     return embeddings.astype(np.float32)
 
+def get_document_tier_weight(source_name: str, path: str = "") -> float:
+    """
+    Determine the retrieval boost weight for a document based on its tier.
+    - Tier 1: 19th Main Agreement & Standards of Conduct (default 1.2)
+    - Tier 3: Statutory and general secondary resources (default 0.8)
+    - Tier 2: Core agreements, jurisprudence, forms, etc. (default 1.0)
+    """
+    tier1_boost = float(os.getenv("AGNAV_TIER1_BOOST", "1.2"))
+    tier3_boost = float(os.getenv("AGNAV_TIER3_BOOST", "0.8"))
+
+    # Normalise input paths and source names for robust matching
+    path_lower = path.lower().replace("\\", "/")
+    source_lower = source_name.lower()
+
+    # Tier 1 checks:
+    # 1. Gov BC Standards of Conduct (either via relative path or source name)
+    # 2. BCGEU 19th Main Agreement (either via relative path or source name)
+    is_standards_of_conduct = (
+        "standards_of_conduct" in path_lower 
+        or "standards of conduct" in source_lower
+    )
+    is_19th_agreement = (
+        "19th_main_agreement" in path_lower 
+        or "19th main agreement" in source_lower
+    )
+
+    if is_standards_of_conduct or is_19th_agreement:
+        return tier1_boost
+
+    # Tier 3 checks:
+    # 1. Statutory regulations: '02_statutory/' folder or source names
+    # 2. Other general resources: '03_resources/' folder except Standards of Conduct
+    is_statutory = (
+        "02_statutory" in path_lower 
+        or "statutory" in path_lower
+        or "ohs_regulation" in path_lower
+        or "workers_compensation" in path_lower
+    )
+    is_general_resource = (
+        "03_resources" in path_lower
+        and not is_standards_of_conduct
+    )
+
+    if is_statutory or is_general_resource:
+        return tier3_boost
+
+    # Tier 2: Default
+    return 1.0
+
 def search_index(index: "faiss.IndexFlatIP", chunks: list[dict], query: str, top_k: int | None = None) -> list[dict]:
-    import faiss
     if top_k is None:
         top_k = SIMILARITY_TOP_K
     
-    query_vec = embed_texts([query])
-
-    faiss.normalize_L2(query_vec)
-    _scores, indices = index.search(query_vec, top_k)
-    return [chunks[i] for i in indices[0] if i < len(chunks)]
+    # Reuse the batch-based search implementation with score weighting
+    results = search_index_batch(index, chunks, [query], [top_k])
+    return results[0] if results else []
 
 def search_index_batch(index: "faiss.IndexFlatIP", chunks: list[dict], queries: list[str], top_ks: list[int]) -> list[list[dict]]:
     """
     Search multiple queries in a single embedding pass to reduce CPU overhead.
     Uses FAISS's native batch search for maximum efficiency (#323).
+    Applies document-tier score boosting to retrieve context preferentially.
     """
     import faiss
     import numpy as np
@@ -288,15 +344,46 @@ def search_index_batch(index: "faiss.IndexFlatIP", chunks: list[dict], queries: 
     query_vecs = embed_texts(queries)
     faiss.normalize_L2(query_vecs)
     
-    # 2. Batch Search (FAISS native multi-vector search)
+    # 2. Determine a larger candidate pool size for re-ranking
+    # We retrieve more candidates from FAISS so that top-tier matches 
+    # can bubble up through re-ranking.
     max_k = max(top_ks)
-    _scores, all_indices = index.search(query_vecs, max_k)
+    candidate_k = max(max_k * 3, 50)
+    # Ensure candidate_k does not exceed total indexed chunks
+    candidate_k = min(candidate_k, len(chunks))
+    if candidate_k <= 0:
+        return [[] for _ in queries]
+    
+    # 3. Batch Search (FAISS native multi-vector search)
+    scores, all_indices = index.search(query_vecs, candidate_k)
     
     results = []
     for i, indices in enumerate(all_indices):
-        # Truncate to the specific top_k for this query perspective
+        query_scores = scores[i]
         k = top_ks[i]
-        results.append([chunks[idx] for idx in indices[:k] if 0 <= idx < len(chunks)])
+        
+        # Build candidate chunks with original and weighted scores
+        candidates = []
+        for idx_in_search, chunk_idx in enumerate(indices):
+            if 0 <= chunk_idx < len(chunks):
+                chunk = chunks[chunk_idx]
+                orig_score = float(query_scores[idx_in_search])
+                
+                # Determine weight based on tier
+                weight = get_document_tier_weight(
+                    chunk.get("source", ""),
+                    chunk.get("path", "")
+                )
+                weighted_score = orig_score * weight
+                
+                candidates.append((chunk, weighted_score))
+        
+        # Sort candidates by weighted score in descending order
+        candidates.sort(key=lambda item: item[1], reverse=True)
+        
+        # Extract the top-k chunks
+        top_k_chunks = [item[0] for item in candidates[:k]]
+        results.append(top_k_chunks)
         
     return results
 
@@ -346,6 +433,7 @@ def build_index_from_sources(force: bool = False) -> tuple[Any, Any] | tuple[Non
             "chunk_size": CHUNK_SIZE,
             "chunk_overlap": CHUNK_OVERLAP,
             "embed_model": EMBED_MODEL,
+            "tiering_version": "v1",
         },
         "files": {}
     }

--- a/app/tests/test_index.py
+++ b/app/tests/test_index.py
@@ -103,4 +103,83 @@ def test_search_index_finds_most_similar(monkeypatch):
     assert results[0] == chunks[2]
 
 
+def test_get_document_tier_weight():
+    """Verify that get_document_tier_weight returns correct weights for all tiers."""
+    # Tier 1 documents
+    assert indexing.get_document_tier_weight("BCGEU 19th Main Agreement", "01_primary/BCGEU_19th_Main_Agreement.md") == 1.2
+    assert indexing.get_document_tier_weight("Gov BC Standards of Conduct", "03_resources/Gov_BC_Standards_of_Conduct.md") == 1.2
+    
+    # Matching by source name only or path only (robustness checks)
+    assert indexing.get_document_tier_weight("Gov BC Standards of Conduct", "") == 1.2
+    assert indexing.get_document_tier_weight("", "03_resources/Gov_BC_Standards_of_Conduct.md") == 1.2
+    assert indexing.get_document_tier_weight("BCGEU 19th Main Agreement", "") == 1.2
+    assert indexing.get_document_tier_weight("", "01_primary/BCGEU_19th_Main_Agreement.md") == 1.2
+    
+    # Tier 2 documents (unmodified)
+    assert indexing.get_document_tier_weight("BC Labour Relations Code", "01_primary/BC_Labour_Relations_Code.md") == 1.0
+    assert indexing.get_document_tier_weight("Nexus Test and Off-Duty Conduct", "04_jurisprudence/Nexus_Test_and_Off-Duty_Conduct.md") == 1.0
+    assert indexing.get_document_tier_weight("BCGEU Grievance Form Guide", "forms/BCGEU_Grievance_Form_Guide.md") == 1.0
+    
+    # Tier 3 documents (de-boosted)
+    assert indexing.get_document_tier_weight("BC Employment Standards Act", "02_statutory/BC_Employment_Standards_Act.md") == 0.8
+    assert indexing.get_document_tier_weight("BC OHS Regulation - Part 07", "02_statutory/BC_OHS_Regulation_-_Part_07.md") == 0.8
+    assert indexing.get_document_tier_weight("BCGEU Steward Resources", "03_resources/BCGEU_Steward_Resources.md") == 0.8
+
+
+def test_search_index_boosts_tier_1_documents(monkeypatch):
+    """search_index should boost a Tier 1 document (BCGEU 19th Main Agreement) to rank above a slightly closer Tier 3 document."""
+    # 2 chunks: 
+    # chunk 0: Tier 3 document (OHS Regulation)
+    # chunk 1: Tier 1 document (19th Agreement)
+    chunks = [
+        {
+            "text": "OHS regulation chunk",
+            "page": 1,
+            "source": "BC OHS Regulation - Part 07",
+            "path": "02_statutory/BC_OHS_Regulation_-_Part_07.md",
+            "chunk_index": 0
+        },
+        {
+            "text": "19th main agreement chunk",
+            "page": 5,
+            "source": "BCGEU 19th Main Agreement",
+            "path": "01_primary/BCGEU_19th_Main_Agreement.md",
+            "chunk_index": 1
+        }
+    ]
+    
+    # We will construct a query vec q, and database vecs v0, v1 such that:
+    # q . v0 = 0.9 (chunk 0, Tier 3)
+    # q . v1 = 0.8 (chunk 1, Tier 1)
+    
+    EMBED_DIM = indexing.EMBED_DIM
+    q = np.zeros((1, EMBED_DIM), dtype=np.float32)
+    q[0, 0] = 1.0 # query is along axis 0
+    
+    v0 = np.zeros((1, EMBED_DIM), dtype=np.float32)
+    v0[0, 0] = 0.9
+    v0[0, 1] = np.sqrt(1 - 0.9**2) # norm is 1.0, dot product with q is 0.9
+    
+    v1 = np.zeros((1, EMBED_DIM), dtype=np.float32)
+    v1[0, 0] = 0.8
+    v1[0, 1] = np.sqrt(1 - 0.8**2) # norm is 1.0, dot product with q is 0.8
+    
+    vecs = np.vstack([v0, v1])
+    
+    monkeypatch.setattr(indexing, "embed_texts", _make_embed_fn(vecs))
+    index = indexing.build_index(chunks)
+    
+    # For query search, mock embed_texts to return q
+    monkeypatch.setattr(indexing, "embed_texts", lambda _texts: q.copy())
+    
+    # Unweighted search would find chunk 0 first since dot product 0.9 > 0.8.
+    # But with tier boosting:
+    # chunk 0 (Tier 3): 0.9 * 0.8 (Tier 3 weight) = 0.72
+    # chunk 1 (Tier 1): 0.8 * 1.2 (Tier 1 weight) = 0.96
+    # So chunk 1 should be boosted to the top!
+    results = indexing.search_index(index, chunks, "query text", top_k=1)
+    
+    assert results[0] == chunks[1]
+
+
 


### PR DESCRIPTION
### Summary
This PR implements **Document Tiering & Score Boosting** for RAG retrieval to prioritize collective agreements and standards of conduct over massive statutory text (Issue #391).

### Key Changes
1. **Source/Path Metadata Tracking**: Enhanced chunk ingestion (`chunk_text`, `load_md_chunks`, `load_pdf_chunks`) to track relative path info.
2. **Tier Weights Mapping**: Added `get_document_tier_weight()` mapped to env vars (`AGNAV_TIER1_BOOST` defaulting to `1.2` and `AGNAV_TIER3_BOOST` defaulting to `0.8`).
   - **Tier 1 (1.2)**: `BCGEU 19th Main Agreement` & `Gov BC Standards of Conduct`.
   - **Tier 2 (1.0)**: Other primary agreements, jurisprudence, forms, grievance guides.
   - **Tier 3 (0.8)**: Secondary statutory regulations (e.g., OHS Regulation, Workers Compensation Act parts) and general resources.
3. **Score Weighting & Re-ranking**: Refactored `search_index_batch` to search FAISS for a larger candidate pool (`max(top_k * 3, 50)`), apply tier weights to each candidate's similarity score, re-sort, and slice the top `top_k`.
4. **Smart Cache Rebuilding**: Added `tiering_version` to the config manifest hash to automatically trigger a rebuild on next startup.
5. **Robust Test Coverage**: Added high-fidelity unit tests (`test_get_document_tier_weight`, `test_search_index_boosts_tier_1_documents`) asserting exact mathematical score boosting and rank promotion.

Closes #391