### PR TITLE
chore(git): ignore privacy.md bind-mount host target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,6 @@ reports/
 
 # Dynamic build metadata
 app/public/build_metadata.json
+
+# Auto-created host mount point from container volumes
+app/public/docs/PRIVACY.md


### PR DESCRIPTION
This PR ignores the auto-created PRIVACY.md host mount point file created by the container runtime. Closes #512