### PR TITLE
refactor(models): flagship Qwen3-32B cloud, tinyllama local

### DIFF
--- a/app/SPEC.md
+++ b/app/SPEC.md
@@ -104,6 +104,7 @@ Agreement Navigator includes an automated "Adversarial Reviewer" that double-che
 | `AGNAV_PASSWORD` | *(None)* | Basic Auth password (enables auth if set) |
 | `AGNAV_LLM_PROVIDER` | `huggingface` | `huggingface` or `ollama` |
 | `AGNAV_DEFAULT_MODEL` | `Qwen/Qwen3-32B` | Primary LLM for responses |
+| `AGNAV_HF_PROVIDER` | `featherless-ai` | Provider suffix for HF Router (e.g., `featherless-ai`, `together`) |
 | `HF_TOKEN` | *(Required for HF)* | Hugging Face API token |
 | `PORT` | `7860` | Application port |
 | `SIMILARITY_TOP_K` | `40` | Number of chunks retrieved |

--- a/app/SPEC.md
+++ b/app/SPEC.md
@@ -22,7 +22,7 @@ To reduce the "Information Gap" for union stewards by providing a mobile-first, 
 | **Interface** | Chainlit 2.11 | Rapid, high-performance web UI with native streaming support. |
 | **Logic** | Python 3.14 | Standard for LLM orchestration and RAG pipelines. |
 | **LLM (PROD)** | Hugging Face Router | Access to Qwen/Qwen3-32B via high-speed "Flash" API. |
-| **LLM (DEV)** | Ollama | Local execution of qwen3:4b-instruct for zero-config, offline development. |
+| **LLM (DEV)** | Ollama | Local execution of tinyllama for zero-config, containerized development. |
 | **Embeddings** | `BAAI/bge-small-en-v1.5` | State-of-the-art local CPU embeddings; avoids 3GB CUDA dependencies. |
 | **Vector Store** | FAISS | Ultra-fast, in-memory CPU vector index; requires no database server. |
 | **Deployment** | Podman / HF Spaces | Containerized deployment with immutable production parity. |

--- a/app/SPEC.md
+++ b/app/SPEC.md
@@ -21,8 +21,8 @@ To reduce the "Information Gap" for union stewards by providing a mobile-first, 
 |---|---|---|
 | **Interface** | Chainlit 2.11 | Rapid, high-performance web UI with native streaming support. |
 | **Logic** | Python 3.14 | Standard for LLM orchestration and RAG pipelines. |
-| **LLM (PROD)** | Hugging Face Router | Access to Qwen/Qwen3-14B via high-speed "Flash" API. |
-| **LLM (DEV)** | Ollama | Local execution of qwen3:14b for zero-config, offline development. |
+| **LLM (PROD)** | Hugging Face Router | Access to Qwen/Qwen3-32B via high-speed "Flash" API. |
+| **LLM (DEV)** | Ollama | Local execution of qwen3:4b-instruct for zero-config, offline development. |
 | **Embeddings** | `BAAI/bge-small-en-v1.5` | State-of-the-art local CPU embeddings; avoids 3GB CUDA dependencies. |
 | **Vector Store** | FAISS | Ultra-fast, in-memory CPU vector index; requires no database server. |
 | **Deployment** | Podman / HF Spaces | Containerized deployment with immutable production parity. |
@@ -68,7 +68,7 @@ Agreement Navigator moves beyond messy PDF-to-text extraction by using a special
 
 | Component | Rate | Estimated Monthly (moderate use) |
 |---|---|---|
-| **Hugging Face Router** | Qwen3-14B (Flash) | ~$5–10 CAD |
+| **Hugging Face Router** | Qwen3-32B (Flash) | ~$5–10 CAD |
 | **Embeddings** | `bge-small-en-v1.5` | $0 (Runs locally on CPU) |
 | **Total** | | **~$5–15 CAD/month** |
 
@@ -103,7 +103,7 @@ Agreement Navigator includes an automated "Adversarial Reviewer" that double-che
 | `AGNAV_USERNAME` | `admin` | Basic Auth username |
 | `AGNAV_PASSWORD` | *(None)* | Basic Auth password (enables auth if set) |
 | `AGNAV_LLM_PROVIDER` | `huggingface` | `huggingface` or `ollama` |
-| `AGNAV_DEFAULT_MODEL` | `Qwen/Qwen3-14B` | Primary LLM for responses |
+| `AGNAV_DEFAULT_MODEL` | `Qwen/Qwen3-32B` | Primary LLM for responses |
 | `HF_TOKEN` | *(Required for HF)* | Hugging Face API token |
 | `PORT` | `7860` | Application port |
 | `SIMILARITY_TOP_K` | `40` | Number of chunks retrieved |

--- a/app/main.py
+++ b/app/main.py
@@ -54,7 +54,7 @@ from indexing import (
 
 # ─── Global State & Config ──────────────────────────────────────────────────
 # Single Source of Truth for local development models.
-OLLAMA_MODEL_ID = "qwen3:14b"
+OLLAMA_MODEL_ID = "qwen3:4b-instruct"
 # Allow environment override for CI (e.g. tinyllama for smoke tests)
 CURRENT_MODEL_ID = os.getenv("OLLAMA_MODEL_ID", OLLAMA_MODEL_ID)
 
@@ -95,10 +95,10 @@ def _get_default_model():
     if provider == "ollama":
         val = os.getenv("OLLAMA_MODEL")
         return val if (val and val.strip()) else CURRENT_MODEL_ID
-    return "Qwen/Qwen3-14B"
+    return "Qwen/Qwen3-32B"
 
 DEFAULT_MODEL_LLM = os.getenv("AGNAV_DEFAULT_MODEL", _get_default_model())
-HF_PROVIDER = os.getenv("AGNAV_HF_PROVIDER", "").strip()
+HF_PROVIDER = os.getenv("AGNAV_HF_PROVIDER", "featherless-ai").strip()
 CLAUDE_MODEL = os.getenv("AGNAV_CLAUDE_MODEL", DEFAULT_MODEL_LLM)
 REVIEWER_MODEL = os.getenv("AGNAV_REVIEWER_MODEL", DEFAULT_MODEL_LLM)
 CONDENSE_MODEL = os.getenv("AGNAV_CONDENSE_MODEL", DEFAULT_MODEL_LLM)

--- a/app/main.py
+++ b/app/main.py
@@ -54,7 +54,7 @@ from indexing import (
 
 # ─── Global State & Config ──────────────────────────────────────────────────
 # Single Source of Truth for local development models.
-OLLAMA_MODEL_ID = "qwen3:4b-instruct"
+OLLAMA_MODEL_ID = "tinyllama"
 # Allow environment override for CI (e.g. tinyllama for smoke tests)
 CURRENT_MODEL_ID = os.getenv("OLLAMA_MODEL_ID", OLLAMA_MODEL_ID)
 

--- a/tests/deploy_integrity/test_deploy_integrity.py
+++ b/tests/deploy_integrity/test_deploy_integrity.py
@@ -145,7 +145,7 @@ def test_manifest_source_files_exist():
 
 
 def test_no_qwen_2_5_fallback_downgrade():
-    """Ensures that the LLM configuration remains strictly aligned to Qwen3 models."""
+    """Ensures that the LLM configuration remains strictly aligned to Qwen3 flagship models."""
     app_path = REPO_ROOT / "app" / "main.py"
     content = app_path.read_text()
     
@@ -153,9 +153,9 @@ def test_no_qwen_2_5_fallback_downgrade():
     assert "Qwen/Qwen2.5" not in content, \
         "Code Quality regression: Swapping default fallback models to Qwen 2.5 is prohibited. Keep flagship Qwen3."
     
-    # Verify the fallback model returned in _get_default_model is Qwen3
-    assert re.search(r'return\s+["\']Qwen/Qwen3-\w+["\']', content), \
-        "Code Quality regression: fallback model return value in main.py must be a standardized Qwen3 model."
+    # Verify the fallback model returned in _get_default_model is exactly Qwen3-32B
+    assert re.search(r'return\s+["\']Qwen/Qwen3-32B["\']', content), \
+        "Code Quality regression: fallback model return value in main.py must be the flagship Qwen/Qwen3-32B model."
 
 
 def test_python_version_integrity():


### PR DESCRIPTION
## Description
This Pull Request restores our flagship reasoning engine to the cloud and aligns local development to a strict, container-first paradigm.

### Key Changes
1. **👑 Flagship Cloud Recovery:** Reverted the cloud default LLM fallback to **`Qwen/Qwen3-32B`** with dedicated **`featherless-ai`** provider routing to secure premium, concise answer quality and detailed asynchronous verification notes for stewards.
2. **🐳 Enforced Container Parity:** Aligned the Python codebase local default Ollama model to **`tinyllama`**, matching our containerized `compose.yml` configuration out-of-the-box.
3. **📊 Specs & Integration Sync:** Synchronized `app/SPEC.md` and our automated integrity tests (`test_no_qwen_2_5_fallback_downgrade`) to assert `Qwen3-32B` is strictly locked in as the production fallback standard, protecting the codebase from future silent downgrades.