### PR TITLE
feat(compose): pin stable ollama image version to 0.5.7

### DIFF
--- a/app/compose.yml
+++ b/app/compose.yml
@@ -127,7 +127,7 @@ services:
   # and serving the pulled models in RAM/VRAM on port 11434.
   ollama:
     container_name: vexilon-ollama
-    image: ollama/ollama:latest
+    image: ollama/ollama:0.5.7
     ports: ["11434:11434"]
     environment:
       OLLAMA_FLASH_ATTENTION: 1
@@ -147,7 +147,7 @@ services:
   # Fails loudly on network error so developer knows their dev env is broken.
   ollama-init: &ollama-init-service
     container_name: vexilon-ollama-init
-    image: ollama/ollama:latest
+    image: ollama/ollama:0.5.7
     depends_on:
       ollama:
         condition: service_healthy


### PR DESCRIPTION
Pin both the ollama and ollama-init helper services to stable version 0.5.7 in compose.yml to prevent mutable tag breakages.

Closes #537