### PR TITLE
fix(ci): rename token input to github_token in deploy workflows

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -26,7 +26,7 @@ jobs:
         uses: bcgov/actions/image-tracker@main
         with:
           package: agnav
-          token: ${{ github.token }}
+          github_token: ${{ github.token }}
           revision: ${{ github.sha }}
           max_depth: 20
 

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -33,7 +33,7 @@ jobs:
         uses: bcgov/actions/image-tracker@main
         with:
           package: agnav
-          token: ${{ github.token }}
+          github_token: ${{ github.token }}
           revision: ${{ github.event.pull_request.head.sha || github.sha }}
           max_depth: 20
 


### PR DESCRIPTION
Renames the input parameter for the image-tracker action from 'token' to 'github_token' in both deploy-test.yml and deploy-prod.yml. This aligns our deploy pipelines with the upstream updates and resolves the unexpected input error. Closes #549