### PR TITLE
refactor(ci): simplify oci auditing, remove fragile build-arg versions

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -276,9 +276,6 @@ jobs:
           package: agnav
           build_context: app
           build_file: app/Containerfile
-          build_args: |
-            VERSION=sha-${{ github.event.pull_request.head.sha }}
-            REPO_URL=https://github.com/${{ github.repository }}
 
   trivy:
     name: Trivy Security Scan

--- a/app/Containerfile
+++ b/app/Containerfile
@@ -102,9 +102,4 @@ COPY --from=model_fetcher /model /model
 RUN mkdir -p /hf_cache && chown -R app:app /hf_cache
 USER 1000
 
-ARG VERSION
-ARG REPO_URL
-ENV AGNAV_VERSION=$VERSION \
-    AGNAV_REPO_URL=$REPO_URL
-
 CMD ["sh", "-c", "TRANSFORMERS_OFFLINE=1 HF_HUB_OFFLINE=0 chainlit run main.py --host 0.0.0.0 --port 7860 --headless"]

--- a/app/chainlit.md
+++ b/app/chainlit.md
@@ -33,7 +33,3 @@ For more information about our zero-storage model, see our [Privacy Policy](http
 * [Grievance - C - Steward Case](/public/docs/forms/Grievance_-_C_-_Steward_Case.pdf)
 * [BCGEU Grievance Form Guide](/public/docs/forms/BCGEU_Grievance_Form_Guide.md)
 * [Policy Grievance Form Guide](/public/docs/forms/Policy_Grievance_Form_Guide.md)
-
----
-
-`{{BUILD_SHA}}`

--- a/app/main.py
+++ b/app/main.py
@@ -71,7 +71,7 @@ INTEGRITY_WARNING: str | None = None
 _background_tasks: set[asyncio.Task] = set()
 
 AGNAV_VERSION = os.getenv("AGNAV_VERSION", "Dev mode")
-IS_DEV = "dev" in AGNAV_VERSION.lower()
+IS_DEV = not os.getenv("SPACE_ID")
 AGNAV_REPO_URL = os.getenv("AGNAV_REPO_URL", "https://github.com/MinionTech/vexilon")
 GITHUB_DATA_URL = os.getenv(
     "AGNAV_KNOWLEDGE_URL", f"{AGNAV_REPO_URL}/tree/main/app/data"


### PR DESCRIPTION
This PR cleans up the fragile build-time version and repo URL injection that caused drift between registry tags and the running container version. It relies purely on registry OCI labels and OCI digest resolution, returning us to a clean, stable, and highly auditable architecture.