### PR TITLE
fix(ci): catch results false positive

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -315,14 +315,28 @@ jobs:
         with:
           sarif_file: "trivy-results.sarif"
 
+  # ==========================================================================
+  # WARNING: This job acts as the required merge gate for this workflow.
+  # If you add a new job to this workflow, you MUST add its ID to the 'needs'
+  # array below, otherwise its failure or cancellation will not block the PR!
+  # ==========================================================================
   results:
     name: Results
     needs: [build, test-integration-model, test-integration-app, test-e2e, validate-cache, trivy]
     if: always()
     runs-on: ubuntu-slim
+    timeout-minutes: 1
     steps:
-      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      - name: Log Job Results Context
         run: |
-          echo "At least one required job has failed or was cancelled."
+          echo "=== Upstream Job Statuses ==="
+          echo '${{ toJson(needs) }}'
+
+      - name: Evaluate Overall Status
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "❌ Critical Check Failure: At least one required job has failed or was cancelled."
           exit 1
-      - run: echo "All critical checks passed or were intentionally skipped."
+
+      - name: Success Message
+        run: echo "✅ All critical checks passed or were intentionally skipped!"

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -321,8 +321,8 @@ jobs:
     if: always()
     runs-on: ubuntu-slim
     steps:
-      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'canceled')
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
-          echo "At least one required job has failed or was canceled."
+          echo "At least one required job has failed or was cancelled."
           exit 1
       - run: echo "All critical checks passed or were intentionally skipped."


### PR DESCRIPTION
This PR corrects the spelling of 'cancelled' (with two 'l's) in GitHub Actions status check and log messages. This prevents false positive passes when job statuses are checked.