### PR TITLE
ci(deploy): enhance robustness of test and prod HF deployments

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -128,9 +128,23 @@ git commit -m "promote: $IMAGE_REF from $ORIGINAL_REF"
 git remote remove hf 2>/dev/null || true
 git remote add hf "https://huggingface.co/spaces/${SPACE_NAME}"
 
-# Helper to retry a command once after a 2-second sleep if it fails
+# Helper to retry a command up to 3 times with a 10-second sleep
 retry() {
-    "$@" || (echo "[warning] Command '$1' failed. Retrying in 2s..." && sleep 2 && "$@")
+    local max=3
+    local delay=10
+    local attempt=1
+    while true; do
+        if "$@"; then
+            return 0
+        fi
+        if (( attempt >= max )); then
+            echo "[error] Command '$1' failed after $max attempts."
+            return 1
+        fi
+        echo "[warning] Command '$1' failed. Retrying in ${delay}s (Attempt $((attempt+1))/$max)..."
+        sleep "$delay"
+        ((attempt++))
+    done
 }
 
 # Push using an authenticated URL to avoid modifying local git config

--- a/.github/scripts/verify_deployment.sh
+++ b/.github/scripts/verify_deployment.sh
@@ -90,7 +90,7 @@ SPACE_URL="https://$(echo "$SPACE_ID" | tr '[:upper:]' '[:lower:]' | tr '/' '-')
 
 # Since the server may take a few seconds to fully initialize even after the Space
 # status reports 'running', we run the probe with a brief retry loop.
-MAX_RETRIES=6
+MAX_RETRIES=12
 RETRY_INTERVAL=10
 CURL_EXIT=0
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -36,7 +36,22 @@ jobs:
           TEST: "true"
         run: |
           TAG=$(echo '${{ steps.resolve.outputs.images }}' | jq -r '.agnav')
-          ./.github/scripts/deploy.sh "bcgeu/navigator" "$TAG"
+          MAX_ATTEMPTS=3
+          for i in $(seq 1 $MAX_ATTEMPTS); do
+            echo "::group::Attempt $i of $MAX_ATTEMPTS"
+            if ./.github/scripts/deploy.sh "bcgeu/navigator" "$TAG"; then
+              echo "✅ Deployment succeeded on attempt $i!"
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ $i -lt $MAX_ATTEMPTS ]; then
+              echo "⚠️ Attempt $i failed. Retrying in 15 seconds..."
+              sleep 15
+            fi
+          done
+          echo "❌ Deployment failed after $MAX_ATTEMPTS attempts."
+          exit 1
 
       - name: Notify Owners on Failure
         if: failure()

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -41,7 +41,23 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           TEST: "true"
-        run: ./.github/scripts/deploy.sh "bcgeu/navigator-test" "${{ steps.resolve.outputs.image }}"
+        run: |
+          MAX_ATTEMPTS=3
+          for i in $(seq 1 $MAX_ATTEMPTS); do
+            echo "::group::Attempt $i of $MAX_ATTEMPTS"
+            if ./.github/scripts/deploy.sh "bcgeu/navigator-test" "${{ steps.resolve.outputs.image }}"; then
+              echo "✅ Deployment succeeded on attempt $i!"
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ $i -lt $MAX_ATTEMPTS ]; then
+              echo "⚠️ Attempt $i failed. Retrying in 15 seconds..."
+              sleep 15
+            fi
+          done
+          echo "❌ Deployment failed after $MAX_ATTEMPTS attempts."
+          exit 1
 
       - name: Notify Owners on Failure
         if: failure()

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -45,7 +45,7 @@ jobs:
           MAX_ATTEMPTS=3
           for i in $(seq 1 $MAX_ATTEMPTS); do
             echo "::group::Attempt $i of $MAX_ATTEMPTS"
-            if ./.github/scripts/deploy.sh "bcgeu/navigator-test" "${{ steps.resolve.outputs.image }}"; then
+            if ./.github/scripts/deploy.sh "bcgeu/navigator-test" "${{ inputs.image_tag || steps.resolve.outputs.image }}"; then
               echo "✅ Deployment succeeded on attempt $i!"
               echo "::endgroup::"
               exit 0


### PR DESCRIPTION
This PR comprehensively hardens the Hugging Face Space deployment pipeline against transient network drops, builder crashes, and slow boot times.

**Changes:**
- Added a 3-attempt workflow-level retry loop around the deployment steps in both `deploy-test.yml` and `deploy-prod.yml`.
- Increased the `/api/version` functional smoke test polling timeout in `verify_deployment.sh` from 60s to 120s to give HF containers enough time to download model weights and spin up.
- Enhanced the `git push` logic in `deploy.sh` to retry up to 3 times with a 10s delay (previously 1 retry with a 2s delay).
- Fixed a bug in `deploy-test.yml` where manual `workflow_dispatch` runs ignored the provided `image_tag` input.

Closes #583