### PR TITLE
fix(security): enforce root-ownership of hf_cache

### DIFF
--- a/app/Containerfile
+++ b/app/Containerfile
@@ -85,7 +85,7 @@ COPY tests/ ./tests/
 
 # Prepare directories for local testing and Chainlit runtime with non-root ownership
 RUN mkdir -p /app/reports /app/.pytest_cache /hf_cache /app/.files /app/.pdf_cache && \
-    chown -R 1000:1000 /app/reports /app/.pytest_cache /hf_cache /app/.files /app/.pdf_cache /app/.chainlit
+    chown -R 1000:1000 /app/reports /app/.pytest_cache /app/.files /app/.pdf_cache /app/.chainlit
 
 # ─── Stage 3: Minimal, Hardened Production Runner ─────────────────────────────
 # The clean, locked-down image compiled for production deployments.
@@ -100,7 +100,7 @@ COPY --chown=app:app --from=builder /venv /venv
 COPY --chown=app:app --from=builder /app /app
 COPY --from=model_fetcher /model /model
 
-RUN mkdir -p /hf_cache && chown -R app:app /hf_cache
+RUN mkdir -p /hf_cache
 USER 1000
 
 CMD ["sh", "-c", "TRANSFORMERS_OFFLINE=1 HF_HUB_OFFLINE=0 chainlit run main.py --host 0.0.0.0 --port 7860 --headless"]

--- a/tests/deploy_integrity/test_deploy_integrity.py
+++ b/tests/deploy_integrity/test_deploy_integrity.py
@@ -74,8 +74,7 @@ def test_hf_cache_security_lock():
     content = containerfile_path.read_text()
     
     # Ensure there is NO chown assigning hf_cache to the app user
-    assert not re.search(r"chown\s+.*?app:app\s+(?:/app/\.pytest_cache\s+)?/hf_cache", content) and \
-           not re.search(r"chown\s+.*?1000:1000\s+.*?/hf_cache", content), \
+    assert not re.search(r"chown\s+.*?\b(?:app|1000)\b.*?/hf_cache", content), \
         "Security Breach: hf_cache MUST NOT be owned by the app user. Revert the chown to root."
 
 

--- a/tests/deploy_integrity/test_deploy_integrity.py
+++ b/tests/deploy_integrity/test_deploy_integrity.py
@@ -73,10 +73,9 @@ def test_hf_cache_security_lock():
     containerfile_path = REPO_ROOT / "app" / "Containerfile"
     content = containerfile_path.read_text()
     
-    # Ensure there is NO --chown=1001:1001 on the hf_cache line
-    # Broken version: COPY --from=builder --chown=1001:1001 /app/hf_cache /app/hf_cache
-    # Safe version: COPY --from=builder /app/hf_cache /app/hf_cache
-    assert "--chown=1001:1001 /app/hf_cache" not in content, \
+    # Ensure there is NO chown assigning hf_cache to the app user
+    assert not re.search(r"chown\s+.*?app:app\s+(?:/app/\.pytest_cache\s+)?/hf_cache", content) and \
+           not re.search(r"chown\s+.*?1000:1000\s+.*?/hf_cache", content), \
         "Security Breach: hf_cache MUST NOT be owned by the app user. Revert the chown to root."
 
 


### PR DESCRIPTION
Resolves #585

**Summary of changes:**
1. Reverted `/hf_cache` to root ownership in `Containerfile` (Stages 2 & 3).
2. Fixed the deploy integrity test regex to accurately catch any attempt to `chown` the cache back to the app user.
3. Verified via local `podman` build that `HF_HUB_OFFLINE=0` does not crash the app when the cache is read-only.