### PR TITLE
chore(ci): clearly point renovate config at main branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Presets from https://github.com/bcgov/renovate-config",
   "extends": [
-    "github>bcgov/renovate-config"
+    "github>bcgov/renovate-config#main"
   ],
   "minimumReleaseAge": "3 days"
 }


### PR DESCRIPTION
The previous method works, but is generating Renovate PRs.  This should make intent clear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency maintenance configuration to use the explicitly specified main branch of the shared configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->