### PR TITLE
chore(agents): remove redundant root tool symlinks

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-.agents/AGENTS.md

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,1 +1,0 @@
-.agents/AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-.agents/AGENTS.md


### PR DESCRIPTION
### Candidate Overview

This PR removes redundant root tool symlinks (`.cursorrules`, `CLAUDE.md`, `.windsurfrules`) to eliminate root directory clutter.

#### Key Changes
- Removed root symlinks `.cursorrules`, `CLAUDE.md`, and `.windsurfrules`.
- Retained canonical `.agents/AGENTS.md` (AGY/Linux Foundation standard) and `.github/copilot-instructions.md` (GitHub Copilot standard).

#### Verification
- Root directory verified clean.
- Existing AGY and Copilot instructions remain intact.