### PR TITLE
fix(ui): sanitize upstream 429 errors and send user notifications on rate limits

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -785,6 +785,21 @@ async def get_rag_context(message: str, history: list[dict]) -> tuple[list[str],
     return queries, "\n\n".join(context_parts), unique_snippets
 
 
+HIGH_TRAFFIC_MESSAGE = "⏳ The AI service is currently experiencing high traffic. Please wait a moment and try again."
+GENERIC_ERROR_MESSAGE = "⚠️ An unexpected error occurred while processing your request. Please try again."
+
+def format_rag_error_message(exc: Exception) -> str:
+    """Map exceptions to user-facing error messages, hiding internal error details."""
+    if isinstance(exc, openai.RateLimitError):
+        return HIGH_TRAFFIC_MESSAGE
+
+    err_str = str(exc).lower()
+    if any(k in err_str for k in ("429", "rate_limit", "rate-limit", "queue_exceeded", "queue-exceeded", "over capacity", "over_capacity")):
+        return HIGH_TRAFFIC_MESSAGE
+
+    return GENERIC_ERROR_MESSAGE
+
+
 async def rag_review_stream(message: str, history: list[dict], persona_mode: str = "Lookup", context: str | None = None, queries: list[str] | None = None) -> AsyncIterator[str]:
     try:
         if not context or not queries:
@@ -793,8 +808,6 @@ async def rag_review_stream(message: str, history: list[dict], persona_mode: str
             queries = queries or q_new
 
         # 2. Forensic Analysis & Logic Injection
-        # Removed unused variable (was identical to base_persona)
-        
         base_persona = get_persona_prompt(persona_mode)
         audit_rules = ""
         if persona_mode in ("Grieve", "Manage"):
@@ -821,16 +834,9 @@ async def rag_review_stream(message: str, history: list[dict], persona_mode: str
             messages=messages
         ):
             yield text
-    except openai.RateLimitError as exc:
-        logger.error(f"[rag] Upstream rate limit error: {exc}", exc_info=True)
-        yield "⏳ The AI service is currently experiencing high traffic. Please wait a moment and try again."
     except Exception as exc:
         logger.error(f"[rag] Pipeline error: {exc}", exc_info=True)
-        err_str = str(exc).lower()
-        if "429" in err_str or "rate_limit" in err_str or "queue_exceeded" in err_str or "over capacity" in err_str:
-            yield "⏳ The AI service is currently experiencing high traffic. Please wait a moment and try again."
-        else:
-            yield "⚠️ An unexpected error occurred while processing your request. Please try again."
+        yield format_rag_error_message(exc)
 
 # ─── UI Utility Functions ───────────────────────────────────────────────────
 def _get_download_source_files() -> list[Path]:

--- a/app/main.py
+++ b/app/main.py
@@ -821,9 +821,16 @@ async def rag_review_stream(message: str, history: list[dict], persona_mode: str
             messages=messages
         ):
             yield text
+    except openai.RateLimitError as exc:
+        logger.error(f"[rag] Upstream rate limit error: {exc}", exc_info=True)
+        yield "⏳ The AI service is currently experiencing high traffic. Please wait a moment and try again."
     except Exception as exc:
         logger.error(f"[rag] Pipeline error: {exc}", exc_info=True)
-        yield f"⚠️ API error: {exc}"
+        err_str = str(exc).lower()
+        if "429" in err_str or "rate_limit" in err_str or "queue_exceeded" in err_str or "over capacity" in err_str:
+            yield "⏳ The AI service is currently experiencing high traffic. Please wait a moment and try again."
+        else:
+            yield "⚠️ An unexpected error occurred while processing your request. Please try again."
 
 # ─── UI Utility Functions ───────────────────────────────────────────────────
 def _get_download_source_files() -> list[Path]:
@@ -1222,11 +1229,13 @@ async def on_message(message: cl.Message) -> None:
     # Rate limit (per session)
     allowed, rate_msg = _rate_limiter.is_allowed(_client_id())
     if not allowed:
+        await cl.Message(content=rate_msg or "⚠️ Rate limit exceeded. Please wait before sending another message.").send()
         return
 
     # Prompt-injection / length sanitisation
     sanitized, flagged = sanitize_input(msg_str)
     if flagged:
+        await cl.Message(content="⚠️ Your request contained invalid input or exceeded maximum length.").send()
         return
 
     # Order of precedence: session['persona'] (settings) -> session['chat_profile'] (profiles) -> DEFAULT_PERSONA

--- a/app/tests/test_rag_stream.py
+++ b/app/tests/test_rag_stream.py
@@ -184,3 +184,37 @@ async def test_rag_review_stream_generic_error_sanitized(monkeypatch):
     assert len(output) == 1
     assert "⚠️" in output[0]
     assert "Internal secret details" not in output[0]
+
+async def test_rag_review_stream_queue_exceeded_fallback(monkeypatch):
+    """RuntimeErrors containing 'queue_exceeded' must yield high-traffic message, distinct from generic error sanitization."""
+    async def _mock_context(*args, **kwargs):
+        return ["query"], "context", []
+
+    monkeypatch.setattr(app, "get_rag_context", _mock_context)
+
+    async def _raising_stream(**kwargs):
+        raise RuntimeError("queue_exceeded")
+        yield  # Make it an async generator
+
+    monkeypatch.setattr(app, "unified_chat_stream", _raising_stream)
+
+    output = []
+    async for chunk in app.rag_review_stream("Any question", []):
+        output.append(chunk)
+    assert len(output) == 1
+    assert "⏳" in output[0]
+    assert "experiencing high traffic" in output[0]
+
+async def test_rag_review_stream_get_rag_context_failure(monkeypatch):
+    """Pre-stream failures in get_rag_context should be caught and formatted cleanly."""
+    async def _failing_context(*args, **kwargs):
+        raise RuntimeError("rate_limit exceeded during retrieval")
+
+    monkeypatch.setattr(app, "get_rag_context", _failing_context)
+
+    output = []
+    async for chunk in app.rag_review_stream("Any question", []):
+        output.append(chunk)
+    assert len(output) == 1
+    assert "⏳" in output[0]
+    assert "experiencing high traffic" in output[0]

--- a/app/tests/test_rag_stream.py
+++ b/app/tests/test_rag_stream.py
@@ -140,4 +140,47 @@ async def test_rag_stream_api_error_yields_error_message(monkeypatch):
         output.append(chunk)
     assert len(output) == 1
     assert "⚠️" in output[0]
-    assert "API error" in output[0]
+
+async def test_rag_review_stream_rate_limit_error(monkeypatch):
+    """When an upstream RateLimitError occurs, yield user-friendly 429 message."""
+    async def _mock_context(*args, **kwargs):
+        return ["query"], "context", []
+
+    monkeypatch.setattr(app, "get_rag_context", _mock_context)
+
+    async def _raising_stream(**kwargs):
+        raise openai.RateLimitError(
+            message="queue_exceeded",
+            response=MagicMock(status_code=429),
+            body={"type": "too_many_requests_error"},
+        )
+        yield  # Make it an async generator
+
+    monkeypatch.setattr(app, "unified_chat_stream", _raising_stream)
+
+    output = []
+    async for chunk in app.rag_review_stream("Any question", []):
+        output.append(chunk)
+    assert len(output) == 1
+    assert "⏳" in output[0]
+    assert "experiencing high traffic" in output[0]
+
+async def test_rag_review_stream_generic_error_sanitized(monkeypatch):
+    """Generic errors in rag_review_stream must yield sanitized error messages."""
+    async def _mock_context(*args, **kwargs):
+        return ["query"], "context", []
+
+    monkeypatch.setattr(app, "get_rag_context", _mock_context)
+
+    async def _raising_stream(**kwargs):
+        raise RuntimeError("Internal secret details")
+        yield  # Make it an async generator
+
+    monkeypatch.setattr(app, "unified_chat_stream", _raising_stream)
+
+    output = []
+    async for chunk in app.rag_review_stream("Any question", []):
+        output.append(chunk)
+    assert len(output) == 1
+    assert "⚠️" in output[0]
+    assert "Internal secret details" not in output[0]


### PR DESCRIPTION
## Summary

Fixes #624 by catching `openai.RateLimitError` and upstream 429 status codes in `rag_review_stream` using a shared `format_rag_error_message()` helper, yielding a clean user-friendly notification (`⏳ The AI service is currently experiencing high traffic. Please wait a moment and try again.`) instead of raw JSON API exception payloads. Also updates `@cl.on_message` to send explicit user notifications when in-app rate limits or input sanitization flags are triggered.

## Key Changes

- **Shared Error Mapper**: Introduced `format_rag_error_message(exc)` in `app/main.py` to handle both `get_rag_context` pre-stream failures and `unified_chat_stream` errors uniformly.
- **Capacity & Rate Limit Mapping**: Maps HTTP 429, `rate_limit`, `queue_exceeded`, and `over_capacity` errors to `HIGH_TRAFFIC_MESSAGE`; returns `GENERIC_ERROR_MESSAGE` for all other exceptions, hiding raw JSON/internal exception strings.
- **UI Notifications**: Updated `@cl.on_message` rate-limiting and sanitization guards to notify the user via `cl.Message(...).send()` rather than returning silently.
- **Unit Test Expansion**: Added unit tests in `app/tests/test_rag_stream.py` covering rate-limit handling, `queue_exceeded` fallback, generic error sanitization, and pre-stream context failure handling.

Closes #624