### PR TITLE
fix(prompts): use canonical relative form links, add Manage mode guard, and use explicit form PDF allow-list

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -414,10 +414,10 @@ UNION_MANDATORY_RULES = """--- MANDATORY OPERATIONAL RULES (UNION) ---
 3. STRUCTURE: Use clear headings, bullet points, and numbered lists to organize complex answers.
 4. NO MERIT ASSESSMENT: Do NOT judge the merit or likelihood of success of a grievance.
 5. GRIEVANCE FILING & FORMS: Facilitate the filing process by identifying potential contract violations. When asked about grievance forms or filing a grievance, inform the user that official forms are available and provide these exact links:
-   - [Grievance - 0 - Instructions](https://raw.githubusercontent.com/MinionTech/vexilon/main/app/public/docs/forms/Grievance_-_0_-_Instructions.pdf)
-   - [Grievance - A - Grievor Case](https://raw.githubusercontent.com/MinionTech/vexilon/main/app/public/docs/forms/Grievance_-_A_-_Grievor_Case.pdf)
-   - [Grievance - B - Notify Designates](https://raw.githubusercontent.com/MinionTech/vexilon/main/app/public/docs/forms/Grievance_-_B_-_Notify_Designates.pdf)
-   - [Grievance - C - Steward Case](https://raw.githubusercontent.com/MinionTech/vexilon/main/app/public/docs/forms/Grievance_-_C_-_Steward_Case.pdf)
+   - [Grievance - 0 - Instructions](/public/docs/forms/Grievance_-_0_-_Instructions.pdf)
+   - [Grievance - A - Grievor Case](/public/docs/forms/Grievance_-_A_-_Grievor_Case.pdf)
+   - [Grievance - B - Notify Designates](/public/docs/forms/Grievance_-_B_-_Notify_Designates.pdf)
+   - [Grievance - C - Steward Case](/public/docs/forms/Grievance_-_C_-_Steward_Case.pdf)
 """
 
 MANAGER_MANDATORY_RULES = """--- MANDATORY OPERATIONAL RULES (MANAGEMENT) ---
@@ -1290,20 +1290,28 @@ async def on_message(message: cl.Message) -> None:
                     ))
                 seen_sources.add(source_name)
 
-        # Auto-attach grievance form PDFs if user query involves filing a grievance or asking for forms
-        query_lower = sanitized.lower()
-        if any(kw in query_lower for kw in ("grievance form", "grievance forms", "form a", "form b", "form c", "file a grievance", "grieve", "grievance")):
-            forms_dir = PUBLIC_DOCS_DIR / "forms"
-            if forms_dir.exists():
-                for pdf_form in sorted(forms_dir.glob("*.pdf")):
-                    if pdf_form.name not in seen_sources:
-                        elements.append(cl.File(
-                            name=f"{pdf_form.stem.replace('_', ' ')} (PDF)",
-                            path=str(pdf_form),
-                            mime="application/pdf",
-                            display="inline",
-                        ))
-                        seen_sources.add(pdf_form.name)
+        # Auto-attach grievance form PDFs if user query involves filing a grievance or asking for forms (disabled in Manage mode)
+        ALLOWED_FORM_PDFS = (
+            "Grievance_-_0_-_Instructions.pdf",
+            "Grievance_-_A_-_Grievor_Case.pdf",
+            "Grievance_-_B_-_Notify_Designates.pdf",
+            "Grievance_-_C_-_Steward_Case.pdf",
+        )
+        if persona != "Manage":
+            query_lower = sanitized.lower()
+            if any(kw in query_lower for kw in ("grievance form", "grievance forms", "form a", "form b", "form c", "file a grievance", "grieve", "grievance")):
+                forms_dir = PUBLIC_DOCS_DIR / "forms"
+                if forms_dir.exists():
+                    for form_filename in ALLOWED_FORM_PDFS:
+                        pdf_form = forms_dir / form_filename
+                        if pdf_form.exists() and pdf_form.name not in seen_sources:
+                            elements.append(cl.File(
+                                name=f"{pdf_form.stem.replace('_', ' ')} (PDF)",
+                                path=str(pdf_form),
+                                mime="application/pdf",
+                                display="inline",
+                            ))
+                            seen_sources.add(pdf_form.name)
 
         out.elements = elements
 

--- a/app/main.py
+++ b/app/main.py
@@ -408,11 +408,16 @@ _ALL_SIMPLE_KEYWORDS = _SIMPLE_KEYWORDS | _JOKE_KEYWORDS
 
 UNION_MANDATORY_RULES = """--- MANDATORY OPERATIONAL RULES (UNION) ---
 1. ANSWER FROM EXCERPTS ONLY: Base your answer strictly on the provided excerpts.
+   EXCEPTION: When asked for grievance forms, filing a grievance, or grievance documentation, you MUST provide the official form download links listed in Rule 5 below.
 2. STRICT CITATIONS: Every claim MUST be supported by a verbatim quote followed by its citation.
    EXAMPLE: > "verbatim text" [Document Name, Page X]
 3. STRUCTURE: Use clear headings, bullet points, and numbered lists to organize complex answers.
 4. NO MERIT ASSESSMENT: Do NOT judge the merit or likelihood of success of a grievance.
-5. GRIEVANCE FILING: Facilitate the filing process by identifying potential contract violations.
+5. GRIEVANCE FILING & FORMS: Facilitate the filing process by identifying potential contract violations. When asked about grievance forms or filing a grievance, inform the user that official forms are available and provide these exact links:
+   - [Grievance - 0 - Instructions](https://raw.githubusercontent.com/MinionTech/vexilon/main/app/public/docs/forms/Grievance_-_0_-_Instructions.pdf)
+   - [Grievance - A - Grievor Case](https://raw.githubusercontent.com/MinionTech/vexilon/main/app/public/docs/forms/Grievance_-_A_-_Grievor_Case.pdf)
+   - [Grievance - B - Notify Designates](https://raw.githubusercontent.com/MinionTech/vexilon/main/app/public/docs/forms/Grievance_-_B_-_Notify_Designates.pdf)
+   - [Grievance - C - Steward Case](https://raw.githubusercontent.com/MinionTech/vexilon/main/app/public/docs/forms/Grievance_-_C_-_Steward_Case.pdf)
 """
 
 MANAGER_MANDATORY_RULES = """--- MANDATORY OPERATIONAL RULES (MANAGEMENT) ---
@@ -446,8 +451,8 @@ def get_persona_prompt(persona_key: str) -> str:
     else:
         rules = UNION_MANDATORY_RULES
         persona = (
-            "You are a forensic labor law expert. Your goal is to provide precise, fact-based answers using ONLY the provided context.\n"
-            "If the information is not in the context, state that you don't know."
+            "You are a forensic labor law expert. Your goal is to provide precise, fact-based answers using the provided context.\n"
+            "If asked for grievance forms or how to file a grievance, assist the user by providing the official form links listed in the rules."
         )
     
     return f"{rules}\n\nROLE: {persona}"
@@ -1284,6 +1289,22 @@ async def on_message(message: cl.Message) -> None:
                         display="inline",
                     ))
                 seen_sources.add(source_name)
+
+        # Auto-attach grievance form PDFs if user query involves filing a grievance or asking for forms
+        query_lower = sanitized.lower()
+        if any(kw in query_lower for kw in ("grievance form", "grievance forms", "form a", "form b", "form c", "file a grievance", "grieve", "grievance")):
+            forms_dir = PUBLIC_DOCS_DIR / "forms"
+            if forms_dir.exists():
+                for pdf_form in sorted(forms_dir.glob("*.pdf")):
+                    if pdf_form.name not in seen_sources:
+                        elements.append(cl.File(
+                            name=f"{pdf_form.stem.replace('_', ' ')} (PDF)",
+                            path=str(pdf_form),
+                            mime="application/pdf",
+                            display="inline",
+                        ))
+                        seen_sources.add(pdf_form.name)
+
         out.elements = elements
 
         first_token_received = False


### PR DESCRIPTION
## Problem & Review Verification

1. **Canonical Form Links**: Updated `UNION_MANDATORY_RULES` in `app/main.py` (L417-420) to use canonical deployed `/public/docs/forms/...` paths matching `app/chainlit.md` instead of raw GitHub URLs.
2. **Manage Mode Guard**: Added `persona != "Manage"` guard around the auto-attachment flow in `on_message` so grievance form attachments are disabled for management sessions.
3. **Explicit Form PDF Allow-List**: Replaced wildcard `forms_dir.glob("*.pdf")` with an explicit tuple `ALLOWED_FORM_PDFS` containing only the four intended form PDF filenames (`Grievance_-_0_-_Instructions.pdf`, `Grievance_-_A_-_Grievor_Case.pdf`, `Grievance_-_B_-_Notify_Designates.pdf`, `Grievance_-_C_-_Steward_Case.pdf`).

## Key Changes

- **Canonical Deployed Links**:
  - `[Grievance - 0 - Instructions](/public/docs/forms/Grievance_-_0_-_Instructions.pdf)`
  - `[Grievance - A - Grievor Case](/public/docs/forms/Grievance_-_A_-_Grievor_Case.pdf)`
  - `[Grievance - B - Notify Designates](/public/docs/forms/Grievance_-_B_-_Notify_Designates.pdf)`
  - `[Grievance - C - Steward Case](/public/docs/forms/Grievance_-_C_-_Steward_Case.pdf)`
- **`on_message` Auto-Attachment Guard**: Wrapped form auto-attachment with `if persona != "Manage":`.
- **Explicit Allow-List**: Restricted PDF iteration to `ALLOWED_FORM_PDFS`.

## Verification

- **Tests**: `uv run pytest tests/` -> 111 passed, 0 failures.
- **Python Runtime**: Python 3.14.6 via `uv`.

Closes #623

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added official download links for grievance forms 0, A, B, and C.
  * Grievance-related responses now automatically include matching PDF forms when available.
  * Updated guidance directs users to the appropriate forms when requesting assistance with grievance filing.
  * Duplicate form attachments are avoided when multiple grievance-related documents are relevant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->