### PR TITLE
fix(verification): eliminate static form link false-alarms, mandate forensic analysis before form links, and format clean chip labels

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -413,7 +413,7 @@ UNION_MANDATORY_RULES = """--- MANDATORY OPERATIONAL RULES (UNION) ---
    EXAMPLE: > "verbatim text" [Document Name, Page X]
 3. STRUCTURE: Use clear headings, bullet points, and numbered lists to organize complex answers.
 4. NO MERIT ASSESSMENT: Do NOT judge the merit or likelihood of success of a grievance.
-5. GRIEVANCE FILING & FORMS: Facilitate the filing process by identifying potential contract violations. When asked about grievance forms or filing a grievance, inform the user that official forms are available and provide these exact links:
+5. GRIEVANCE FILING & FORMS: Facilitate the filing process by identifying potential contract violations. When asked about grievance forms or filing a grievance, ALWAYS provide a brief forensic analysis of the user's situation and relevant contract provisions FIRST, followed by informing the user that official forms are available and providing these exact links:
    - [Grievance - 0 - Instructions](/public/docs/forms/Grievance_-_0_-_Instructions.pdf)
    - [Grievance - A - Grievor Case](/public/docs/forms/Grievance_-_A_-_Grievor_Case.pdf)
    - [Grievance - B - Notify Designates](/public/docs/forms/Grievance_-_B_-_Notify_Designates.pdf)
@@ -465,6 +465,8 @@ For each claim in the response:
 1. Check if the quoted text actually supports the claim being made
 2. Check if the citation (document name, article/section, page number) is accurate
 3. Identify any hallucinations, misquotes, or unsupported claims
+
+NOTE: Static system resources (such as official grievance form links like /public/docs/forms/...) are official application assets provided by the platform. Do NOT flag official form links or document downloads as DISPUTED or unsupported claims.
 
 Respond in this format:
 - VERIFIED: [claim summary] — the quote supports the claim
@@ -640,12 +642,26 @@ async def unified_chat_stream(model: str, messages: list, system: str | list = N
 async def verify_response(assistant_response: str, context: str) -> str:
     if not VERIFY_ENABLED: return ""
     try:
-        return await unified_chat_create(
+        raw_verification = await unified_chat_create(
             model=VERIFY_MODEL,
             max_tokens=512,
             system=VERIFY_SYSTEM_PROMPT,
             messages=[{"role": "user", "content": f"RESPONSE:\n{assistant_response}\n\nCONTEXT:\n{context}"}]
         )
+        if not raw_verification:
+            return "ALL_CLAIMS_VERIFIED"
+        
+        # Filter out false-alarm DISPUTED lines regarding static form links
+        lines = [line.strip() for line in raw_verification.split("\n") if line.strip()]
+        filtered_lines = []
+        for line in lines:
+            if "DISPUTED:" in line and any(kw in line.lower() for kw in ("/public/docs/forms", "official form", "grievance form", "grievance document", "provided links")):
+                continue
+            filtered_lines.append(line)
+
+        if not filtered_lines or all("VERIFIED:" in l or l == "ALL_CLAIMS_VERIFIED" for l in filtered_lines):
+            return "ALL_CLAIMS_VERIFIED"
+        return "\n".join(filtered_lines)
     except Exception as exc:
         return f"⚠️ Verification unavailable: {exc}"
 
@@ -1297,6 +1313,12 @@ async def on_message(message: cl.Message) -> None:
             "Grievance_-_B_-_Notify_Designates.pdf",
             "Grievance_-_C_-_Steward_Case.pdf",
         )
+        CHIP_DISPLAY_NAMES = {
+            "Grievance_-_0_-_Instructions.pdf": "Instructions (PDF)",
+            "Grievance_-_A_-_Grievor_Case.pdf": "Form A - Grievor (PDF)",
+            "Grievance_-_B_-_Notify_Designates.pdf": "Form B - Designate (PDF)",
+            "Grievance_-_C_-_Steward_Case.pdf": "Form C - Steward (PDF)",
+        }
         if persona != "Manage":
             query_lower = sanitized.lower()
             if any(kw in query_lower for kw in ("grievance form", "grievance forms", "form a", "form b", "form c", "file a grievance", "grieve", "grievance")):
@@ -1305,8 +1327,9 @@ async def on_message(message: cl.Message) -> None:
                     for form_filename in ALLOWED_FORM_PDFS:
                         pdf_form = forms_dir / form_filename
                         if pdf_form.exists() and pdf_form.name not in seen_sources:
+                            display_name = CHIP_DISPLAY_NAMES.get(form_filename, f"{pdf_form.stem.replace('_', ' ')} (PDF)")
                             elements.append(cl.File(
-                                name=f"{pdf_form.stem.replace('_', ' ')} (PDF)",
+                                name=display_name,
                                 path=str(pdf_form),
                                 mime="application/pdf",
                                 display="inline",

--- a/app/main.py
+++ b/app/main.py
@@ -651,15 +651,26 @@ async def verify_response(assistant_response: str, context: str) -> str:
         if not raw_verification:
             return "ALL_CLAIMS_VERIFIED"
         
-        # Filter out false-alarm DISPUTED lines regarding static form links
+        # Filter out false-alarm DISPUTED lines regarding explicit static form URLs or downloads
         lines = [line.strip() for line in raw_verification.split("\n") if line.strip()]
         filtered_lines = []
         for line in lines:
-            if "DISPUTED:" in line and any(kw in line.lower() for kw in ("/public/docs/forms", "official form", "grievance form", "grievance document", "provided links")):
+            line_lower = line.lower()
+            if "disputed:" in line_lower and any(kw in line_lower for kw in ("/public/docs/forms/", "form download link")):
                 continue
             filtered_lines.append(line)
 
-        if not filtered_lines or all("VERIFIED:" in l or l == "ALL_CLAIMS_VERIFIED" for l in filtered_lines):
+        def _normalize_line(line: str) -> str:
+            cleaned = line.strip()
+            if cleaned.startswith(("- ", "* ")):
+                cleaned = cleaned[2:].strip()
+            return cleaned
+
+        normalized_lines = [_normalize_line(line) for line in filtered_lines]
+        if not normalized_lines or all(
+            verification_line.startswith("VERIFIED:") or verification_line == "ALL_CLAIMS_VERIFIED"
+            for verification_line in normalized_lines
+        ):
             return "ALL_CLAIMS_VERIFIED"
         return "\n".join(filtered_lines)
     except Exception as exc:

--- a/app/tests/test_verify_response.py
+++ b/app/tests/test_verify_response.py
@@ -78,12 +78,12 @@ async def test_verify_response_handles_api_error(monkeypatch):
     assert "Verification unavailable" in result
 
 async def test_verify_response_filters_static_form_disputed_lines(monkeypatch):
-    """verify_response should filter out false-alarm DISPUTED lines for static form links."""
+    """verify_response should filter out false-alarm DISPUTED lines for explicit static form URLs."""
     mock_client = MagicMock()
 
     disputed_text = (
-        "DISPUTED: To file a grievance, official forms are available at the provided links — "
-        "the provided source text makes no mention of official forms or provide links to /public/docs/forms/..."
+        "- DISPUTED: To file a grievance, official forms are available at /public/docs/forms/Grievance_-_0_-_Instructions.pdf — "
+        "the provided source text makes no mention of official forms or download links."
     )
     mock_completion = MagicMock()
     mock_completion.choices = [MagicMock(message=MagicMock(content=disputed_text))]
@@ -94,6 +94,25 @@ async def test_verify_response_filters_static_form_disputed_lines(monkeypatch):
     result = await app.verify_response("Response with form links", "Context without form text")
 
     assert result == "ALL_CLAIMS_VERIFIED"
+
+async def test_verify_response_preserves_mixed_disputed_contract_claims(monkeypatch):
+    """verify_response must preserve genuine contract dispute lines even if form URL disputes are present."""
+    mock_client = MagicMock()
+
+    mixed_text = (
+        "- DISPUTED: Form download link /public/docs/forms/Grievance_-_A_-_Grievor_Case.pdf is not in contract text\n"
+        "- DISPUTED: Employee is entitled to 60 days of bereavement leave — Article 20.1 specifies 3 days."
+    )
+    mock_completion = MagicMock()
+    mock_completion.choices = [MagicMock(message=MagicMock(content=mixed_text))]
+    mock_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+
+    monkeypatch.setattr(app, "get_llm_client", lambda: mock_client)
+
+    result = await app.verify_response("Mixed response", "Mixed context")
+
+    assert "60 days of bereavement leave" in result
+    assert "/public/docs/forms/" not in result
 
 async def test_rag_stream_yields_context(monkeypatch):
     """rag_stream should yield context alongside text chunks."""

--- a/app/tests/test_verify_response.py
+++ b/app/tests/test_verify_response.py
@@ -77,6 +77,24 @@ async def test_verify_response_handles_api_error(monkeypatch):
 
     assert "Verification unavailable" in result
 
+async def test_verify_response_filters_static_form_disputed_lines(monkeypatch):
+    """verify_response should filter out false-alarm DISPUTED lines for static form links."""
+    mock_client = MagicMock()
+
+    disputed_text = (
+        "DISPUTED: To file a grievance, official forms are available at the provided links — "
+        "the provided source text makes no mention of official forms or provide links to /public/docs/forms/..."
+    )
+    mock_completion = MagicMock()
+    mock_completion.choices = [MagicMock(message=MagicMock(content=disputed_text))]
+    mock_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+
+    monkeypatch.setattr(app, "get_llm_client", lambda: mock_client)
+
+    result = await app.verify_response("Response with form links", "Context without form text")
+
+    assert result == "ALL_CLAIMS_VERIFIED"
+
 async def test_rag_stream_yields_context(monkeypatch):
     """rag_stream should yield context alongside text chunks."""
     fake_chunks = [


### PR DESCRIPTION
## Summary & Review Verification

1. **Narrowed Static Form URL Filtering ([main.py:L654-L660](file:///home/derek/Repos/vexilon/app/main.py#L654-L660))**:
   - Refined `verify_response()` so it specifically filters out `DISPUTED` lines containing explicit form URLs (`/public/docs/forms/`) or `"form download link"`, preserving valid contract disputes (e.g. bereavement leave, time limits) even if forms are mentioned.
   - Added regression test `test_verify_response_preserves_mixed_disputed_contract_claims` in `app/tests/test_verify_response.py`.
2. **Bullet Normalization & Variable Renaming ([main.py:L662-L670](file:///home/derek/Repos/vexilon/app/main.py#L662-L670))**:
   - Added `_normalize_line()` to strip leading `- ` and `* ` bullets from verification lines.
   - Renamed loop generator variable to `verification_line` and asserted exact `.startswith("VERIFIED:")` or `== "ALL_CLAIMS_VERIFIED"` validation.
3. **Mandatory Forensic Analysis in System Prompt ([main.py:L416](file:///home/derek/Repos/vexilon/app/main.py#L416))**:
   - Instructed the LLM to ALWAYS provide a brief forensic analysis of the user's situation and relevant contract provisions FIRST before listing form download links.
4. **Clean Attachment Chips ([main.py:L1316-L1330](file:///home/derek/Repos/vexilon/app/main.py#L1316-L1330))**:
   - Added `CHIP_DISPLAY_NAMES` mapping for clean, human-readable labels (`Instructions (PDF)`, `Form A - Grievor (PDF)`, etc.).

## Verification

- **Tests**: `uv run pytest tests/` -> 113 passed, 0 failures.
- **Python Runtime**: Python 3.14.6 via `uv`.

Closes #623

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grievance-filing guidance now includes forensic analysis before providing form links.
  * Official grievance-form resources are recognized during verification.
  * Form attachments display clearer, user-facing names.

* **Bug Fixes**
  * Improved handling and normalization of empty verification responses.
  * Prevented false disputed findings for official grievance-form links while preserving genuine disputes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->