### PR TITLE
feat(infra): parameterize Ollama host port mapping via OLLAMA_PORT

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -162,7 +162,7 @@ services:
   ollama:
     container_name: vexilon-ollama
     image: ollama/ollama:0.32.5
-    ports: ["11434:11434"]
+    ports: ["${OLLAMA_PORT:-11434}:11434"]
     environment:
       OLLAMA_FLASH_ATTENTION: 1
       OLLAMA_HOST: 0.0.0.0


### PR DESCRIPTION
## Problem Description

By default, the `ollama` container service hardcoded host port mapping to `11434:11434`. If a developer has a native daemon running on port 11434 or another service bound to that port, `podman compose up` fails with `address already in use`.

## Solution

Parameterize the host port mapping in `compose.yml` ([compose.yml:L165](file:///home/derek/Repos/vexilon/compose.yml#L165)):
```yaml
ports: ["${OLLAMA_PORT:-11434}:11434"]
```

- Defaults to host port `11434`.
- Allows developers to override the host port mapping via `OLLAMA_PORT=11435` in `.env` or shell environment without editing repo files.

## Verification

- **Syntax Validation**: `python3 -c "import yaml; yaml.safe_load(open('compose.yml'))"` passed clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the Ollama service port through the `OLLAMA_PORT` environment variable.
  * Retains port `11434` as the default when no custom value is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->