### PR TITLE
feat(privacy): add pseudonymous client UUID for PIPA-compliant analytics

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -12,7 +12,7 @@ This app is built with a "Privacy-by-Design" architecture, specifically aligned 
 ### 2. Identifying Purposes
 *   **Purpose**: This application processes user queries for the sole purpose of providing context-aware answers in real-time. 
 *   **Tracking**: We only track non-sensitive metadata (query counts and token consumption) for system health and API billing.
-*   **Pseudonymous Client ID**: The browser generates a random UUID (via `crypto.randomUUID()`), stored only in that browser's local storage, to distinguish discrete sessions for rate-limiting integrity and log correlation. It is generated entirely client-side from randomness — never derived from IP address, device fingerprint, or any other real-world identifying information — and is not linked to a user's identity. This satisfies PIPA's allowance for identifying *discrete* users without identifying *who* they are.
+*   **Pseudonymous Client ID**: The browser generates a random UUID (via `crypto.randomUUID()`) and stores it in that browser's local storage. On each session the browser sends this ID to the backend, where it is held in server-side session state (in-memory only, tied to that session — no database) to distinguish discrete sessions for rate-limiting integrity, and it may appear in the operational log lines described in Principle 5. It is generated entirely client-side from randomness — never derived from IP address, device fingerprint, or any other real-world identifying information — and is not linked to a user's real-world identity. This satisfies PIPA's allowance for identifying *discrete* users without identifying *who* they are.
 *   **No Secondary Use**: Data is never used for marketing, profiling, or tracking individual users.
 
 ### 3. Consent
@@ -21,13 +21,13 @@ This app is built with a "Privacy-by-Design" architecture, specifically aligned 
 
 ### 4. Limiting Collection
 *   **Minimal Metrics**: Our collection is strictly limited to non-sensitive performance metrics: **query count** and **token consumption**.
-*   **Content-Blind**: The application does not collect user IP addresses (except for active session rate-limiting in memory), device fingerprints, or location data. The pseudonymous client ID described above does not change this — it is randomly generated, not collected from the user or their device.
+*   **Content-Blind**: The application does not collect user IP addresses (except for active session rate-limiting in memory), device fingerprints, or location data. The pseudonymous client ID described in Principle 2 does not change this — its *value* is randomly generated, not derived from any IP address, device fingerprint, or other data collected from the user's device (though the ID token itself is sent to and briefly held by the server, as described in Principle 2).
 *   **No PII**: We do not require registration or any Personally Identifiable Information (PII) to function.
 
 ### 5. Limiting Use, Disclosure, and Retention
 *   **Ephemeral History**: Chat history exists only in the user's browser session. Refreshing the page permanently deletes the conversation.
 *   **No Persistence**: This application does *not* write user queries or bot responses to a database. 
-*   **Surgical Log Masking**: Technical logs for forensic health monitoring include non-PII metadata (word counts, character counts, and persona modes), but **never** the actual content of user queries or bot responses.
+*   **Surgical Log Masking**: Technical logs for forensic health monitoring include non-PII metadata (word counts, character counts, persona modes, and the pseudonymous client ID from Principle 2), but **never** the actual content of user queries or bot responses. These logs are plain console output written by the application itself; the application does not write them to a database, though the hosting platform's own log capture/retention may apply.
 
 ### 6. Accuracy
 *   **Source Integrity**: This application uses a "Forensic Markdown Pipeline" to ensure that the collective agreements used for grounding are accurate representations of the official source documents.
@@ -45,7 +45,7 @@ This app is built with a "Privacy-by-Design" architecture, specifically aligned 
 ### 9. Individual Access
 *   **Immediate Access**: Users see all data processed (their query) and the resulting output immediately.
 *   **No "Records"**: Because we do not retain data, there are no persistent records for a user to request or correct.
-*   **User Control of Pseudonymous ID**: The client ID is stored in the browser's local storage for this site, not its HTTP cache — clearing the browser's *cache* alone will not remove it. To reset it, use your browser's "Clear site data" / "Cookies and other site data" option for this site (a plain "clear cache" action is not sufficient). Doing so deletes the client ID and severs any correlation between past and future sessions; a new random ID is generated on next use.
+*   **User Control of Pseudonymous ID**: The client ID is stored in the browser's local storage for this site, not its HTTP cache — clearing the browser's *cache* alone will not remove it. To reset it, use your browser's "Clear site data" / "Cookies and other site data" option for this site (a plain "clear cache" action is not sufficient). Doing so deletes the browser's copy and severs correlation with future sessions; a new random ID is generated on next use. It does not retroactively alter operational log lines already written using the old ID (see Principle 5).
 
 ### 10. Challenging Compliance
 *   **Reporting**: Users can report privacy concerns or potential vulnerabilities through GitHub Issues or by contacting the project maintainer.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -45,7 +45,7 @@ This app is built with a "Privacy-by-Design" architecture, specifically aligned 
 ### 9. Individual Access
 *   **Immediate Access**: Users see all data processed (their query) and the resulting output immediately.
 *   **No "Records"**: Because we do not retain data, there are no persistent records for a user to request or correct.
-*   **User Control of Pseudonymous ID**: Clearing browser storage (cache/site data) deletes the client ID and severs any correlation between past and future sessions — a new random ID is generated on next use.
+*   **User Control of Pseudonymous ID**: The client ID is stored in the browser's local storage for this site, not its HTTP cache — clearing the browser's *cache* alone will not remove it. To reset it, use your browser's "Clear site data" / "Cookies and other site data" option for this site (a plain "clear cache" action is not sufficient). Doing so deletes the client ID and severs any correlation between past and future sessions; a new random ID is generated on next use.
 
 ### 10. Challenging Compliance
 *   **Reporting**: Users can report privacy concerns or potential vulnerabilities through GitHub Issues or by contacting the project maintainer.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -12,6 +12,7 @@ This app is built with a "Privacy-by-Design" architecture, specifically aligned 
 ### 2. Identifying Purposes
 *   **Purpose**: This application processes user queries for the sole purpose of providing context-aware answers in real-time. 
 *   **Tracking**: We only track non-sensitive metadata (query counts and token consumption) for system health and API billing.
+*   **Pseudonymous Client ID**: The browser generates a random UUID (via `crypto.randomUUID()`), stored only in that browser's local storage, to distinguish discrete sessions for rate-limiting integrity and log correlation. It is generated entirely client-side from randomness — never derived from IP address, device fingerprint, or any other real-world identifying information — and is not linked to a user's identity. This satisfies PIPA's allowance for identifying *discrete* users without identifying *who* they are.
 *   **No Secondary Use**: Data is never used for marketing, profiling, or tracking individual users.
 
 ### 3. Consent
@@ -20,7 +21,7 @@ This app is built with a "Privacy-by-Design" architecture, specifically aligned 
 
 ### 4. Limiting Collection
 *   **Minimal Metrics**: Our collection is strictly limited to non-sensitive performance metrics: **query count** and **token consumption**.
-*   **Content-Blind**: The application does not collect user IP addresses (except for active session rate-limiting in memory), device fingerprints, or location data.
+*   **Content-Blind**: The application does not collect user IP addresses (except for active session rate-limiting in memory), device fingerprints, or location data. The pseudonymous client ID described above does not change this — it is randomly generated, not collected from the user or their device.
 *   **No PII**: We do not require registration or any Personally Identifiable Information (PII) to function.
 
 ### 5. Limiting Use, Disclosure, and Retention
@@ -44,6 +45,7 @@ This app is built with a "Privacy-by-Design" architecture, specifically aligned 
 ### 9. Individual Access
 *   **Immediate Access**: Users see all data processed (their query) and the resulting output immediately.
 *   **No "Records"**: Because we do not retain data, there are no persistent records for a user to request or correct.
+*   **User Control of Pseudonymous ID**: Clearing browser storage (cache/site data) deletes the client ID and severs any correlation between past and future sessions — a new random ID is generated on next use.
 
 ### 10. Challenging Compliance
 *   **Reporting**: Users can report privacy concerns or potential vulnerabilities through GitHub Issues or by contacting the project maintainer.

--- a/app/main.py
+++ b/app/main.py
@@ -33,6 +33,7 @@ apply_patches()
 import asyncio
 import datetime
 import tempfile
+import uuid
 from collections.abc import AsyncIterator
 from pathlib import Path
 from threading import Lock
@@ -1036,13 +1037,48 @@ async def on_chat_start():
 
 
 # ── Message handler ────────────────────────────────────────────────────────
-def _client_id() -> str:
-    """Best-effort client identifier for rate limiting.
+def _parse_client_uuid(candidate) -> str | None:
+    """Validate a client-supplied UUID string, or None if invalid.
 
-    Chainlit doesn't expose request headers on cl.Message directly; fall back
-    to the session id, which keeps per-user limits sensible without leaking
-    real client IPs.
+    Only accepts well-formed UUID v4 strings so an untrusted window_message
+    payload can't inject arbitrary/oversized content into session state or
+    logs (same defensive posture as sanitize_input()).
     """
+    if not isinstance(candidate, str):
+        return None
+    try:
+        parsed = uuid.UUID(candidate)
+    except (ValueError, AttributeError, TypeError):
+        return None
+    if parsed.version != 4:
+        return None
+    return str(parsed)
+
+
+@cl.on_window_message
+async def on_window_message(data):
+    """Receive the pseudonymous client UUID posted by public/index.js.
+
+    Random, client-generated, browser-local identifier — not derived from
+    IP/device/any real identifying information. See PRIVACY.md.
+    """
+    if not isinstance(data, dict) or data.get("type") != "vexilon_client_id":
+        return
+    client_uuid = _parse_client_uuid(data.get("clientId"))
+    if client_uuid:
+        cl.user_session.set("client_uuid", client_uuid)
+
+
+def _client_id() -> str:
+    """Pseudonymous client identifier for rate limiting and log correlation.
+
+    Prefers the persistent, client-generated UUID captured by
+    on_window_message (survives page reloads); falls back to Chainlit's
+    ephemeral session id for the brief window before the client posts it.
+    """
+    persistent = cl.user_session.get("client_uuid")
+    if persistent:
+        return persistent
     sid = getattr(cl.user_session, "id", None) or cl.user_session.get("id")
     return str(sid) if sid else "default"
 

--- a/app/public/index.js
+++ b/app/public/index.js
@@ -103,4 +103,29 @@
     hideReadmeDrawerTitle();
     replaceBuildSha();
     manageWelcomeTitle();
+
+    // ── Pseudonymous client ID ──────────────────────────────────────────────
+    // Random, client-generated UUID persisted in localStorage. Not derived
+    // from IP/device/any real identifying data — see PRIVACY.md. Used only
+    // to distinguish discrete sessions for rate-limiting and log correlation.
+    function getOrCreateClientId() {
+        let id = localStorage.getItem("vexilon_client_id");
+        if (!id) {
+            id = crypto.randomUUID();
+            localStorage.setItem("vexilon_client_id", id);
+        }
+        return id;
+    }
+
+    const clientId = getOrCreateClientId();
+
+    function postClientId() {
+        window.postMessage({ type: "vexilon_client_id", clientId }, window.location.origin);
+    }
+
+    // Retry briefly in case Chainlit's window-message listener hasn't
+    // mounted yet on first paint.
+    postClientId();
+    setTimeout(postClientId, 300);
+    setTimeout(postClientId, 1000);
 })();

--- a/app/tests/test_client_uuid.py
+++ b/app/tests/test_client_uuid.py
@@ -1,0 +1,54 @@
+"""
+tests/test_client_uuid.py — Unit tests for pseudonymous client UUID handling
+
+Tests verify _parse_client_uuid only accepts well-formed UUID v4 strings,
+rejecting anything that could be used to inject arbitrary content into
+session state or logs via an untrusted window_message payload.
+"""
+
+import uuid
+
+from main import _parse_client_uuid
+
+
+class TestParseClientUuid:
+    """Tests for the _parse_client_uuid validator."""
+
+    def test_accepts_valid_uuid4(self):
+        """A well-formed UUID v4 string should be accepted and normalized."""
+        valid = str(uuid.uuid4())
+        result = _parse_client_uuid(valid)
+        assert result == valid
+
+    def test_accepts_uppercase_uuid4(self):
+        """UUID string casing should not affect validity."""
+        valid = str(uuid.uuid4()).upper()
+        result = _parse_client_uuid(valid)
+        assert result is not None
+
+    def test_rejects_non_uuid_string(self):
+        """Arbitrary strings should be rejected."""
+        assert _parse_client_uuid("not-a-uuid") is None
+
+    def test_rejects_wrong_uuid_version(self):
+        """UUID v1 (e.g. time-based) should be rejected since v4 is required."""
+        v1 = str(uuid.uuid1())
+        assert _parse_client_uuid(v1) is None
+
+    def test_rejects_none(self):
+        """None input should be rejected."""
+        assert _parse_client_uuid(None) is None
+
+    def test_rejects_non_string_types(self):
+        """Non-string payloads (e.g. dict, list, int) should be rejected."""
+        assert _parse_client_uuid(12345) is None
+        assert _parse_client_uuid({"uuid": str(uuid.uuid4())}) is None
+        assert _parse_client_uuid([str(uuid.uuid4())]) is None
+
+    def test_rejects_empty_string(self):
+        """Empty string should be rejected."""
+        assert _parse_client_uuid("") is None
+
+    def test_rejects_oversized_string(self):
+        """Long garbage strings should be rejected, not partially parsed."""
+        assert _parse_client_uuid("a" * 10000) is None


### PR DESCRIPTION
## Summary
- Adds a random, client-generated UUID (`crypto.randomUUID()`, persisted in `localStorage`) to distinguish discrete sessions for rate-limiting and log correlation.
- The identifier is never derived from IP, device fingerprint, or any other real identifying information — it's generated entirely client-side from randomness, satisfying PIPA's allowance for tracking *discrete* users without identifying *who* they are.
- `_client_id()` now prefers this persistent UUID (survives reloads) over the previous ephemeral Chainlit session id, falling back to it for the brief window before the client posts the UUID.
- `PRIVACY.md` updated (Principles 2, 4, 9) to accurately describe the new identifier, reaffirm no IP/device/location data is collected, and correctly document that resetting the ID requires clearing browser *site data*, not just cache (cache alone does not touch `localStorage`).

Closes #354. This implementation is web-only, per the app's actual PWA architecture (no iOS/Android app exists in this repo).

## Test plan
- [x] New unit tests in `app/tests/test_client_uuid.py` covering `_parse_client_uuid` (valid v4 accepted; non-UUID strings, wrong version, non-string/oversized payloads rejected)
- [x] Full test suite passes: `pytest tests/ -q` → 111 passed, 1 skipped
- [x] Manually verified in browser devtools: `localStorage.vexilon_client_id` set on first load, persists across reload
- [x] Manually verified server-side correlation: `docker logs vexilon-dev` shows `[save] Conversation saved by <same uuid>` matching the browser's stored ID
- [x] Manually verified clearing browser *cache* alone does not remove the ID (site data must be cleared instead) — PRIVACY.md wording corrected to match

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persistent, pseudonymous browser ID to support session rate limiting and log correlation.
  * The ID is generated locally and retained across sessions.
  * Users can reset it by clearing site data.

* **Privacy**
  * Clarified that IP addresses, device fingerprints, and location data are not collected for this purpose.

* **Bug Fixes**
  * Added validation to reject invalid or unsafe client IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->